### PR TITLE
#3: Fix linker error caused by stack protector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 ASMFLAGS = --32
-CXXFLAGS = -m32 -fno-use-cxa-atexit -nostdlib -fno-builtin -fno-rtti -fno-exceptions -fno-leading-underscore
+CXXFLAGS = -m32 -fno-use-cxa-atexit -nostdlib -fno-builtin -fno-rtti -fno-exceptions -fno-leading-underscore -fno-stack-protector
 LDFLAGS = -melf_i386
 
 objects = loader.o gdt.o iostream.o driver.o port.o stub.o interrupt.o keyboard.o mouse.o kernel.o


### PR DESCRIPTION
## Summary

- Add `-fno-stack-protector` to `CXXFLAGS` in the Makefile to fix undefined reference to `__stack_chk_fail_local` when linking the kernel binary

Closes #3

## Test plan

- [ ] Run `make clean && make` and verify `cassio.bin` links without errors

Generated with [Claude Code](https://claude.com/claude-code)