### PR TITLE
#22: Add phase 2 tests (interrupts, keyboard, mouse)

### DIFF
--- a/tests/test_interrupt.cpp
+++ b/tests/test_interrupt.cpp
@@ -1,0 +1,58 @@
+#include <hardware/interrupt.hpp>
+#include <hardware/driver.hpp>
+#include <core/gdt.hpp>
+#include "test.hpp"
+
+using namespace cassio;
+using namespace cassio::hardware;
+using namespace cassio::kernel;
+
+TEST(interrupt_flags_values) {
+    ASSERT_EQ(static_cast<u32>(IDT_DESCRIPTOR_PRESENT), 0x80u);
+    ASSERT_EQ(static_cast<u32>(IDT_INTERRUPT_GATE), 0x0Eu);
+}
+
+TEST(interrupt_irq_offset) {
+    ASSERT_EQ(static_cast<u32>(IRQ_OFFSET), 0x20u);
+}
+
+TEST(interrupt_driver_type_keyboard) {
+    ASSERT_EQ(static_cast<u32>(DriverType::KeyboardController), 0x21u);
+}
+
+TEST(interrupt_driver_type_mouse) {
+    ASSERT_EQ(static_cast<u32>(DriverType::MouseController), 0x2Cu);
+}
+
+TEST(interrupt_driver_type_timer) {
+    ASSERT_EQ(static_cast<u32>(DriverType::SystemTimer), 0x20u);
+}
+
+TEST(interrupt_idt_entry_after_load) {
+    GlobalDescriptorTable gdt;
+    InterruptManager& im = InterruptManager::getManager();
+    im.load(gdt);
+
+    // Retrieve IDT base via sidt
+    struct __attribute__((packed)) { u16 limit; u32 base; } idtr;
+    asm volatile("sidt %0" : "=m"(idtr));
+
+    // IDT should have 256 entries of 8 bytes each
+    ASSERT_EQ(static_cast<u32>(idtr.limit), 256u * 8u - 1u);
+
+    // Check entry 0x21 (keyboard IRQ): code_offset should match GDT code segment
+    u8* entry = reinterpret_cast<u8*>(idtr.base) + 0x21 * 8;
+    u16 code_offset = *reinterpret_cast<u16*>(entry + 2);
+    ASSERT_EQ(static_cast<u32>(code_offset), static_cast<u32>(gdt.getCodeOffset()));
+
+    // Access byte should be IDT_DESCRIPTOR_PRESENT | IDT_INTERRUPT_GATE = 0x8E
+    ASSERT_EQ(static_cast<u32>(entry[5]), 0x8Eu);
+
+    // Reserved byte should be 0
+    ASSERT_EQ(static_cast<u32>(entry[4]), 0u);
+
+    // Handler address should be non-zero
+    u32 handler_addr = static_cast<u32>(*reinterpret_cast<u16*>(entry + 6)) << 16
+                     | static_cast<u32>(*reinterpret_cast<u16*>(entry));
+    ASSERT(handler_addr != 0);
+}

--- a/tests/test_keyboard.cpp
+++ b/tests/test_keyboard.cpp
@@ -1,0 +1,43 @@
+#include <drivers/keyboard.hpp>
+#include "test.hpp"
+
+using namespace cassio;
+using namespace cassio::drivers;
+
+TEST(keyboard_command_byte_size) {
+    ASSERT_EQ(static_cast<u32>(sizeof(KeyboardCommandByte)), 1u);
+}
+
+TEST(keyboard_command_constants) {
+    ASSERT_EQ(static_cast<u32>(KeyboardCommand::ReadCommandByte), 0x20u);
+    ASSERT_EQ(static_cast<u32>(KeyboardCommand::WriteCommandByte), 0x60u);
+    ASSERT_EQ(static_cast<u32>(KeyboardCommand::EnableKeyboardInterface), 0xAEu);
+}
+
+TEST(keyboard_keycode_values) {
+    ASSERT_EQ(static_cast<u32>(KeyCode::A), 0x41u);
+    ASSERT_EQ(static_cast<u32>(KeyCode::Z), 0x5Au);
+    ASSERT_EQ(static_cast<u32>(KeyCode::Zero), 0x30u);
+    ASSERT_EQ(static_cast<u32>(KeyCode::Nine), 0x39u);
+    ASSERT_EQ(static_cast<u32>(KeyCode::Enter), 0x0Du);
+    ASSERT_EQ(static_cast<u32>(KeyCode::Space), 0x20u);
+}
+
+TEST(keyboard_command_byte_bits) {
+    KeyboardCommandByte cb;
+    cb.byte = 0;
+
+    cb.keyboard_interrupt = true;
+    ASSERT_EQ(static_cast<u32>(cb.byte & 0x01), 1u);
+
+    cb.byte = 0;
+    cb.mouse_interrupt = true;
+    ASSERT_EQ(static_cast<u32>(cb.byte & 0x02), 2u);
+}
+
+TEST(keyboard_driver_construction) {
+    KeyboardEventHandler handler;
+    KeyboardDriver kbd(&handler);
+    // Construction should not crash; driver self-registers with InterruptManager
+    ASSERT(true);
+}

--- a/tests/test_mouse.cpp
+++ b/tests/test_mouse.cpp
@@ -1,0 +1,25 @@
+#include <drivers/mouse.hpp>
+#include "test.hpp"
+
+using namespace cassio;
+using namespace cassio::drivers;
+
+TEST(mouse_command_constants) {
+    ASSERT_EQ(static_cast<u32>(MouseCommand::ReadCommand), 0x20u);
+    ASSERT_EQ(static_cast<u32>(MouseCommand::WriteCommand), 0x60u);
+    ASSERT_EQ(static_cast<u32>(MouseCommand::EnableMouse), 0xA8u);
+    ASSERT_EQ(static_cast<u32>(MouseCommand::WriteMouse), 0xD4u);
+}
+
+TEST(mouse_event_handler_construction) {
+    MouseEventHandler handler;
+    // Default construction should not crash
+    ASSERT(true);
+}
+
+TEST(mouse_driver_construction) {
+    MouseEventHandler handler;
+    MouseDriver mouse(&handler);
+    // Construction should not crash; driver self-registers with InterruptManager
+    ASSERT(true);
+}


### PR DESCRIPTION
## Summary

- Adds `tests/test_interrupt.cpp` (6 tests) -- IDT flags, IRQ offset, DriverType enum values, and IDT entry layout verification after `load()` using `sidt` to read back the IDT base and validate code_offset, access byte, reserved byte, and handler address
- Adds `tests/test_keyboard.cpp` (5 tests) -- KeyboardCommandByte union size and bit layout, command constants, KeyCode ASCII values, driver construction with self-registration
- Adds `tests/test_mouse.cpp` (3 tests) -- MouseCommand constants, event handler construction, driver construction with self-registration

All 26 tests pass (14 new + 12 existing) via `make test`.

Note: These tests set up the GDT and IDT but do not call `activate()` (no `sti`), so issue #9 (GPF on interrupt return) is not triggered.

Closes #22