### PR TITLE
#10: Clear VGA text buffer on boot

### DIFF
--- a/include/std/iostream.hpp
+++ b/include/std/iostream.hpp
@@ -37,6 +37,8 @@ public:
     ostream& operator<<(const cassio::u32 dword);
     ostream& operator<<(const cassio::u64 qword);
 
+    void clear();
+
     /** Deleted Methods */
     ostream(const ostream&) = delete;
     ostream(ostream&&) = delete;

--- a/src/core/kernel.cpp
+++ b/src/core/kernel.cpp
@@ -67,6 +67,7 @@ void ctors() {
 }
 
 void start(void* multiboot, u32 magic) {
+    std::cout.clear();
     std::cout << "WELCOME TO CASSIO OPERATING SYSTEM!\n";
 
     GlobalDescriptorTable gdt;

--- a/src/std/iostream.cpp
+++ b/src/std/iostream.cpp
@@ -14,12 +14,11 @@ using namespace std;
 
 static ostream cout;
 
-void clear() {
+void ostream::clear() {
     static u16* tty = reinterpret_cast<u16*>(0xb8000);
 
     for (u8 y = 0; y < TERMINAL_HEIGHT; ++y) {
         for (u8 x = 0; x < TERMINAL_WIDTH; ++x) {
-            // Copy High-Bits and Merge with New Low-Bits
             tty[TERMINAL_WIDTH * y + x] = (tty[TERMINAL_WIDTH * y + x] & 0xFF00) | ' ';
         }
     }


### PR DESCRIPTION
## Summary

- Move `clear()` from a free function to a public `ostream::clear()` method
- Call `std::cout.clear()` at the start of `start()` before any output
- Removes leftover SeaBIOS version string from the VGA buffer

Closes #10

## Test plan

- [x] `make` builds without errors
- [x] `make test` passes all 28 tests
- [x] VGA screenshot confirms no BIOS text remnants after boot