### PR TITLE
#18: Fill in empty doxygen comments across the codebase

### DIFF
--- a/include/core/gdt.hpp
+++ b/include/core/gdt.hpp
@@ -16,14 +16,20 @@ namespace cassio {
 namespace kernel {
 
 /**
- * @brief 
- * 
+ * @brief Manages the x86 Global Descriptor Table for memory segmentation.
+ *
+ * Contains null, code, and data segment descriptors. Loads the GDT via lgdt
+ * and reloads all segment registers on construction.
+ *
  */
 class GlobalDescriptorTable {
 public:
     /**
-     * @brief 
-     * 
+     * @brief An 8-byte packed entry describing a memory segment in the GDT.
+     *
+     * Encodes base address, limit, and access flags in the format required
+     * by the x86 processor. Handles both 16-bit and page-granularity limits.
+     *
      */
     class __attribute__((packed)) SegmentDescriptor {
     private:
@@ -36,20 +42,20 @@ public:
 
     public:
         /**
-         * @brief
-         * 
+         * @brief Constructs a segment descriptor with the given base, limit, and access flags.
+         *
          */
         SegmentDescriptor(u32 base, u32 limit, u8 flags);
 
         /**
-         * @brief
-         * 
+         * @brief Decodes and returns the 32-bit base address from this descriptor.
+         *
          */
         u32 getBase();
 
         /**
-         * @brief
-         * 
+         * @brief Decodes and returns the segment limit from this descriptor.
+         *
          */
         u32 getLimit();
 
@@ -57,26 +63,26 @@ public:
 
 public:
     /**
-     * @brief
-     * 
+     * @brief Builds the GDT with null, code, and data segments, then loads it via lgdt.
+     *
      */
     GlobalDescriptorTable();
 
     /**
-     * @brief
-     * 
+     * @brief Destroys the GDT.
+     *
      */
     ~GlobalDescriptorTable();
 
     /**
-     * @brief
-     * 
+     * @brief Returns the byte offset of the code segment descriptor within the GDT.
+     *
      */
     u16 getCodeOffset();
 
     /**
-     * @brief
-     * 
+     * @brief Returns the byte offset of the data segment descriptor within the GDT.
+     *
      */
     u16 getDataOffset();
 

--- a/include/core/kernel.hpp
+++ b/include/core/kernel.hpp
@@ -19,7 +19,7 @@
 #include <std/iostream.hpp>
 
 /**
- * @brief
+ * @brief Function pointer type for global constructors.
  *
  */
 typedef void (*ctor)();
@@ -28,16 +28,16 @@ extern "C" ctor start_ctors;
 extern "C" ctor end_ctors;
 
 /**
- * @brief
+ * @brief Invokes all global constructors between start_ctors and end_ctors.
  *
  */
 extern "C" void ctors();
 
 /**
- * @brief
+ * @brief Kernel entry point called by the bootloader after global constructors.
  *
- * @param multiboot
- * @param magic
+ * @param multiboot Pointer to the Multiboot information structure.
+ * @param magic Multiboot magic number used to verify a valid boot.
  *
  */
 extern "C" void start(void* multiboot, cassio::u32 magic);

--- a/include/drivers/keyboard.hpp
+++ b/include/drivers/keyboard.hpp
@@ -122,9 +122,8 @@ namespace KeyboardCommand {
 }
 
 /**
- * @brief
- * 
- * 
+ * @brief Bitfield layout of the PS/2 controller command byte (port 0x64).
+ *
  */
 union KeyboardCommandByte {
     struct {
@@ -157,29 +156,29 @@ union KeyboardCommandByte {
 };
 
 /**
- * @brief
- * 
+ * @brief Interface for receiving keyboard events from the KeyboardDriver.
+ *
  */
 class KeyboardEventHandler {
 public:
     KeyboardEventHandler() = default;
 
     /**
-     * @brief
+     * @brief Called when a key is pressed. Override to handle key-down events.
      *
      */
     virtual void OnKeyDown(KeyCode key);
 
     /**
-     * @brief
-     * 
+     * @brief Called when a key is released. Override to handle key-up events.
+     *
      */
     virtual void OnKeyUp(KeyCode key);
 };
 
 /**
- * @brief
- * 
+ * @brief PS/2 keyboard driver that translates scancodes into KeyCode events.
+ *
  */
 class KeyboardDriver : public hardware::Driver {
 private:
@@ -193,26 +192,26 @@ private:
 
 public:
     /**
-     * @brief
-     * 
+     * @brief Constructs the keyboard driver with the given event handler.
+     *
      */
     KeyboardDriver(KeyboardEventHandler* han);
 
     /**
-     * @brief
-     * 
+     * @brief Destroys the keyboard driver.
+     *
      */
     ~KeyboardDriver() = default;
 
     /**
-     * @brief
-     * 
+     * @brief Enables keyboard interrupts and clears any pending scancodes.
+     *
      */
     virtual void activate() override;
 
     /**
-     * @brief
-     * 
+     * @brief Reads a scancode from the data port and dispatches it to the event handler.
+     *
      */
     virtual u32 handleInterrupt(u32 esp) override;
 

--- a/include/drivers/mouse.hpp
+++ b/include/drivers/mouse.hpp
@@ -37,41 +37,41 @@ namespace MouseCommand {
 }
 
 /**
- * @brief
- * 
+ * @brief Interface for receiving mouse events from the MouseDriver.
+ *
  */
 class MouseEventHandler {
 public:
     MouseEventHandler() = default;
 
     /**
-     * @brief
-     * 
+     * @brief Called when the mouse driver is activated. Override to set initial state.
+     *
      */
     virtual void OnActivate();
 
     /**
-     * @brief
+     * @brief Called when a mouse button is pressed.
      *
      */
     virtual void OnMouseDown(u8 btn);
 
     /**
-     * @brief
-     * 
+     * @brief Called when a mouse button is released.
+     *
      */
     virtual void OnMouseUp(u8 btn);
 
     /**
-     * @brief
-     * 
+     * @brief Called when the mouse moves by (dx, dy) units.
+     *
      */
     virtual void OnMouseMove(i8 dx, i8 dy);
 };
 
 /**
- * @brief
- * 
+ * @brief PS/2 mouse driver that reads 3-byte packets and dispatches movement/button events.
+ *
  */
 class MouseDriver : public hardware::Driver {
 private:
@@ -83,29 +83,29 @@ private:
     u8 button;
 
     MouseEventHandler* handler;
-    
+
 public:
     /**
-     * @brief
-     * 
+     * @brief Constructs the mouse driver with the given event handler.
+     *
      */
     MouseDriver(MouseEventHandler* han);
 
     /**
-     * @brief
-     * 
+     * @brief Destroys the mouse driver.
+     *
      */
     ~MouseDriver() = default;
 
     /**
-     * @brief
-     * 
+     * @brief Enables the mouse on the PS/2 controller and starts receiving interrupts.
+     *
      */
     virtual void activate() override;
 
     /**
-     * @brief
-     * 
+     * @brief Reads a byte into the 3-byte packet buffer and dispatches events when complete.
+     *
      */
     virtual u32 handleInterrupt(u32 esp) override;
 

--- a/include/hardware/driver.hpp
+++ b/include/hardware/driver.hpp
@@ -44,8 +44,11 @@ enum class DriverType : u8 {
 };
 
 /**
- * @brief
- *  
+ * @brief Base class for hardware drivers that handle IRQ interrupts.
+ *
+ * Registers itself with the InterruptManager on construction using its
+ * DriverType as the interrupt number.
+ *
  */
 class Driver {
 protected:
@@ -53,27 +56,27 @@ protected:
 
 protected:
     /**
-     * @brief
-     * 
+     * @brief Constructs the driver and registers it with the InterruptManager for its IRQ.
+     *
      */
     Driver(DriverType type);
 
     /**
-     * @brief
-     * 
+     * @brief Unregisters the driver from the InterruptManager.
+     *
      */
     ~Driver();
 
 public:
     /**
-     * @brief
-     * 
+     * @brief Activates the driver hardware. Called by DriverManager::load().
+     *
      */
     virtual void activate();
 
     /**
-     * @brief
-     * 
+     * @brief Deactivates the driver hardware. Called by DriverManager::unload().
+     *
      */
     virtual void deactivate();
 
@@ -87,8 +90,8 @@ public:
     virtual i32 reset();
 
     /**
-     * @brief
-     * 
+     * @brief Handles an IRQ interrupt. Returns the (possibly modified) stack pointer.
+     *
      */
     virtual u32 handleInterrupt(u32 esp);
 
@@ -104,8 +107,8 @@ public:
 constexpr u32 NUM_DRIVERS = 256;
 
 /**
- * @brief
- * 
+ * @brief Singleton that holds registered drivers and activates/deactivates them.
+ *
  */
 class DriverManager final {
 private:
@@ -116,41 +119,41 @@ private:
 
 private:
     /**
-     * @brief
-     * 
+     * @brief Constructs the manager with an empty driver list.
+     *
      */
     DriverManager();
 
     /**
-     * @brief
-     * 
+     * @brief Destroys the driver manager.
+     *
      */
     ~DriverManager() = default;
 
 public:
     /**
-     * @brief
-     * 
+     * @brief Returns the singleton DriverManager instance.
+     *
      */
     inline static DriverManager& getManager() {
         return instance;
     }
 
     /**
-     * @brief
-     * 
+     * @brief Adds a driver to the managed list.
+     *
      */
     void addDriver(Driver& drv);
 
     /**
-     * @brief
-     * 
+     * @brief Activates all registered drivers.
+     *
      */
     void load();
 
     /**
-     * @brief
-     * 
+     * @brief Deactivates all registered drivers.
+     *
      */
     void unload();
 

--- a/include/hardware/interrupt.hpp
+++ b/include/hardware/interrupt.hpp
@@ -20,8 +20,8 @@ namespace cassio {
 namespace hardware {
 
 /**
- * @brief
- * 
+ * @brief Flag constants used when building IDT gate descriptors.
+ *
  */
 enum InterruptFlags : u8 {
     IDT_DESCRIPTOR_PRESENT = 0x80,
@@ -29,16 +29,16 @@ enum InterruptFlags : u8 {
 };
 
 /**
- * @brief
- * 
+ * @brief Singleton that owns the IDT and PIC, dispatching hardware interrupts to drivers.
+ *
  */
 class InterruptManager final {
 friend class Driver;
 
 private:
     /**
-     * @brief
-     * 
+     * @brief An 8-byte packed IDT entry pointing to an interrupt handler.
+     *
      */
     struct __attribute__((packed)) GateDescriptor {
         u16 handler_low;
@@ -49,8 +49,8 @@ private:
     };
 
     /**
-     * @brief
-     * 
+     * @brief Pointer structure passed to the lidt instruction (size + base address).
+     *
      */
     struct __attribute__((packed)) InterruptDescriptorTable {
         u16 size;
@@ -70,21 +70,21 @@ private:
 
 private:
     /**
-     * @brief
-     * 
+     * @brief Constructs the manager and initializes PIC ports.
+     *
      */
     InterruptManager();
 
     /**
-     * @brief
-     * 
+     * @brief Destroys the interrupt manager.
+     *
      */
     ~InterruptManager() = default;
 
 public:
     /**
-     * @brief
-     * 
+     * @brief Returns the singleton InterruptManager instance.
+     *
      */
     inline static InterruptManager& getManager() {
         return instance;
@@ -96,38 +96,38 @@ public:
     static void handleInterruptRequest0x0C();
 
     /**
-     * @brief
-     * 
+     * @brief Enables hardware interrupts by executing the sti instruction.
+     *
      */
     void activate();
 
     /**
-     * @brief
-     * 
+     * @brief Disables hardware interrupts by executing the cli instruction.
+     *
      */
     void deactivate();
 
     /**
-     * @brief
-     * 
+     * @brief Dispatches an interrupt to the registered driver or prints a warning.
+     *
      */
     u32 handleInterrupt(u8 number, u32 esp);
 
     /**
-     * @brief
-     * 
+     * @brief Writes a gate descriptor entry into the IDT at the given index.
+     *
      */
     void setInterrupt(u8 number, u16 code_offset, void(*handler)(), u8 access, u8 flags);
 
     /**
-     * @brief
-     * 
+     * @brief Populates the IDT, remaps the PICs, and loads the IDT via lidt.
+     *
      */
     void load(cassio::kernel::GlobalDescriptorTable& gdt);
 
     /**
-     * @brief
-     * 
+     * @brief Unloads the interrupt manager.
+     *
      */
     void unload();
 
@@ -143,7 +143,7 @@ public:
 }
 
 /**
- * @brief
+ * @brief C-linkage interrupt handler called from assembly stubs in stub.s.
  *
  */
 extern "C" cassio::u32 handleInterrupt(cassio::u8 number, cassio::u32 esp);

--- a/include/hardware/port.hpp
+++ b/include/hardware/port.hpp
@@ -16,10 +16,10 @@ namespace cassio {
 namespace hardware {
 
 /**
- * @brief
- * 
+ * @brief Enumerates known x86 I/O port addresses for hardware devices.
+ *
  * @see https://wiki.osdev.org/I/O_Ports
- * 
+ *
  */
 enum class PortType : u16 {
     MasterProgrammableInterfaceControllerCommand        = 0x20,
@@ -40,8 +40,8 @@ enum class PortType : u16 {
 template <typename T> class Port;
 
 /**
- * @brief
- * 
+ * @brief 8-bit I/O port for reading and writing single bytes via in/out instructions.
+ *
  */
 template <> class Port<u8> {
 private:
@@ -49,40 +49,40 @@ private:
 
 public:
     /**
-     * @brief
+     * @brief Constructs a port bound to the given I/O address.
      *
      */
     Port(PortType type);
 
     /**
-     * @brief
+     * @brief Destroys the port.
      *
      */
     ~Port() = default;
 
     /**
-     * @brief
+     * @brief Reads a byte from this I/O port using the inb instruction.
      *
      */
     u8 read();
 
     /**
-     * @brief
-     * 
+     * @brief Writes a byte to this I/O port using the outb instruction.
+     *
      */
     void write(u8 data);
 
     /**
-     * @brief
-     * 
+     * @brief Writes a byte and waits for the bus to settle via a dummy I/O cycle.
+     *
      */
     void writeSlow(u8 data);
 
 };
 
 /**
- * @brief
- * 
+ * @brief 16-bit I/O port for reading and writing words via in/out instructions.
+ *
  */
 template <> class Port<u16> {
 private:
@@ -90,34 +90,34 @@ private:
 
 public:
     /**
-     * @brief
+     * @brief Constructs a port bound to the given I/O address.
      *
      */
     Port(PortType type);
 
     /**
-     * @brief
+     * @brief Destroys the port.
      *
      */
     ~Port() = default;
 
     /**
-     * @brief
+     * @brief Reads a 16-bit word from this I/O port using the inw instruction.
      *
      */
     u16 read();
 
     /**
-     * @brief
-     * 
+     * @brief Writes a 16-bit word to this I/O port using the outw instruction.
+     *
      */
     void write(u16 data);
 
 };
 
 /**
- * @brief
- * 
+ * @brief 32-bit I/O port for reading and writing dwords via in/out instructions.
+ *
  */
 template <> class Port<u32> {
 private:
@@ -125,26 +125,26 @@ private:
 
 public:
     /**
-     * @brief
+     * @brief Constructs a port bound to the given I/O address.
      *
      */
     Port(PortType type);
 
     /**
-     * @brief
+     * @brief Destroys the port.
      *
      */
     ~Port() = default;
 
     /**
-     * @brief
+     * @brief Reads a 32-bit dword from this I/O port using the inl instruction.
      *
      */
     u32 read();
 
     /**
-     * @brief
-     * 
+     * @brief Writes a 32-bit dword to this I/O port using the outl instruction.
+     *
      */
     void write(u32 data);
 

--- a/include/std/iostream.hpp
+++ b/include/std/iostream.hpp
@@ -18,12 +18,12 @@ constexpr cassio::u8 TERMINAL_WIDTH     = 80;
 constexpr cassio::u8 TERMINAL_HEIGHT    = 25;
 
 /**
- * @brief
- * 
- * Each entry in the terminal is 2 bytes, with the first byte containing color information and the
- * second byte containing the character. Therefore, the function will maintain the color information
- * by ANDing with 0xFF00 and adding the new text information with an OR.
- * 
+ * @brief Output stream that writes directly to the VGA text buffer at 0xB8000.
+ *
+ * Each VGA entry is 2 bytes: the high byte holds color attributes and the low byte
+ * holds the character. Write operations preserve existing attributes by masking with
+ * 0xFF00 and ORing in the new character.
+ *
  */
 class ostream {
 public:


### PR DESCRIPTION
## Summary

- Filled in all empty `@brief` doxygen comments across 8 header files
- Covers: gdt.hpp, kernel.hpp, port.hpp, interrupt.hpp, driver.hpp, iostream.hpp, keyboard.hpp, mouse.hpp

Closes #18

## Test plan

- [x] `make` builds without errors
- [x] `make test` passes all 28 tests
- [x] Grep confirms zero remaining empty `@brief` comments in headers