### PR TITLE
#34: Add VgaTerminal tests

### DIFF
--- a/tests/test_terminal.cpp
+++ b/tests/test_terminal.cpp
@@ -1,0 +1,79 @@
+#include <hardware/terminal.hpp>
+#include "test.hpp"
+
+using namespace cassio;
+using namespace cassio::hardware;
+
+TEST(terminal_putchar) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+    vga.clear();
+
+    vga.putchar('X');
+
+    u16* buf = reinterpret_cast<u16*>(0xB8000);
+    ASSERT_EQ(static_cast<u32>(buf[0] & 0x00FF), static_cast<u32>('X'));
+}
+
+TEST(terminal_preserves_attribute) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+    vga.clear();
+
+    u16* buf = reinterpret_cast<u16*>(0xB8000);
+    u16 attr_before = buf[0] & 0xFF00;
+
+    vga.putchar('A');
+
+    u16 attr_after = buf[0] & 0xFF00;
+    ASSERT_EQ(static_cast<u32>(attr_before), static_cast<u32>(attr_after));
+}
+
+TEST(terminal_clear) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+
+    // Write some characters first.
+    vga.putchar('H');
+    vga.putchar('i');
+
+    vga.clear();
+
+    u16* buf = reinterpret_cast<u16*>(0xB8000);
+
+    // First few cells should be spaces.
+    for (u32 i = 0; i < 10; ++i) {
+        ASSERT_EQ(static_cast<u32>(buf[i] & 0x00FF), static_cast<u32>(' '));
+    }
+
+    // Cursor should be at (0,0) -- next putchar writes to buf[0].
+    vga.putchar('Z');
+    ASSERT_EQ(static_cast<u32>(buf[0] & 0x00FF), static_cast<u32>('Z'));
+}
+
+TEST(terminal_newline) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+    vga.clear();
+
+    vga.putchar('\n');
+
+    // Cursor should be at row 1, col 0. Next char goes to buf[80].
+    vga.putchar('N');
+
+    u16* buf = reinterpret_cast<u16*>(0xB8000);
+    ASSERT_EQ(static_cast<u32>(buf[VGA_WIDTH] & 0x00FF), static_cast<u32>('N'));
+}
+
+TEST(terminal_backspace) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+    vga.clear();
+
+    vga.putchar('A');
+    vga.putchar('B');
+    vga.putchar('\b');
+
+    // Backspace should have erased 'B' (replaced with space) and moved cursor back.
+    u16* buf = reinterpret_cast<u16*>(0xB8000);
+    ASSERT_EQ(static_cast<u32>(buf[1] & 0x00FF), static_cast<u32>(' '));
+
+    // Next char should overwrite position 1.
+    vga.putchar('C');
+    ASSERT_EQ(static_cast<u32>(buf[1] & 0x00FF), static_cast<u32>('C'));
+}


### PR DESCRIPTION
## Summary
- Add `tests/test_terminal.cpp` with 5 tests covering VgaTerminal behavior:
  - `terminal_putchar` -- writes a character, verifies it in VGA memory
  - `terminal_preserves_attribute` -- color attribute byte unchanged after write
  - `terminal_clear` -- fills buffer with spaces, resets cursor to (0,0)
  - `terminal_newline` -- `'\n'` advances cursor to next row
  - `terminal_backspace` -- `'\b'` erases character and moves cursor back

Closes #34

## Test plan
- [x] `make test` passes all 33 tests (28 existing + 5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)