### PR TITLE
#48: Refactor shell to use command registry architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,35 +10,40 @@ KERNEL = bin/cassio.bin
 TEST_KERNEL = bin/cassio-test.bin
 ISO = bin/cassio.iso
 
-objects = loader.o gdt.o shell.o driver.o port.o terminal.o stub.o interrupt.o keyboard.o mouse.o physical.o heap.o operators.o paging.o kernel.o
+# Discover all source files automatically.
+cpp_sources = $(shell find src/ -name '*.cpp')
+asm_sources = $(shell find src/ -name '*.s')
+objects = $(patsubst src/%.cpp, obj/%.o, $(cpp_sources)) $(patsubst src/%.s, obj/%.o, $(asm_sources))
 
-# Shared objects for the test kernel (everything except kernel.o)
-shared_objects = loader.o gdt.o shell.o driver.o port.o serial.o terminal.o stub.o interrupt.o keyboard.o mouse.o physical.o heap.o operators.o paging.o
+# Shared objects for the test kernel (everything except kernel.o).
+shared_objects = $(filter-out obj/core/kernel.o, $(objects))
 
-# Test objects are discovered from tests/test_*.cpp
+# Test objects are discovered from tests/test_*.cpp.
 test_sources = $(wildcard tests/test_*.cpp)
-test_objects = $(notdir $(test_sources:.cpp=.o))
+test_objects = $(patsubst tests/%.cpp, obj/tests/%.o, $(test_sources))
 
-%.o: src/*/%.cpp
-	mkdir -p obj
-	g++ $(CXXFLAGS) -o obj/$@ -c $< -Iinclude/
+# Compile C++ source files.
+obj/%.o: src/%.cpp
+	@mkdir -p $(dir $@)
+	g++ $(CXXFLAGS) -o $@ -c $< -Iinclude/
 
-%.o: src/*/%.s
-	mkdir -p obj
-	as $(ASMFLAGS) -o obj/$@ $<
+# Compile assembly source files.
+obj/%.o: src/%.s
+	@mkdir -p $(dir $@)
+	as $(ASMFLAGS) -o $@ $<
 
 kernel: src/linker.ld $(objects)
-	mkdir -p bin
-	ld $(LDFLAGS) -T $< -o $(KERNEL) $(addprefix obj/, $(objects))
+	@mkdir -p bin
+	ld $(LDFLAGS) -T $< -o $(KERNEL) $(objects)
 
-# Compile test files from the tests/ directory
-obj/test_%.o: tests/test_%.cpp
-	mkdir -p obj
+# Compile test files from the tests/ directory.
+obj/tests/%.o: tests/%.cpp
+	@mkdir -p $(dir $@)
 	g++ $(CXXFLAGS) -o $@ -c $< -Iinclude/ -Itests/
 
-$(TEST_KERNEL): src/linker.ld $(shared_objects) $(addprefix obj/, $(test_objects))
-	mkdir -p bin
-	ld $(LDFLAGS) -T $< -o $(TEST_KERNEL) $(addprefix obj/, $(shared_objects)) $(addprefix obj/, $(test_objects))
+$(TEST_KERNEL): src/linker.ld $(shared_objects) $(test_objects)
+	@mkdir -p bin
+	ld $(LDFLAGS) -T $< -o $(TEST_KERNEL) $(shared_objects) $(test_objects)
 
 test: $(TEST_KERNEL)
 	@qemu-system-i386 -machine pc -kernel $(TEST_KERNEL) \

--- a/include/core/commands/clear.hpp
+++ b/include/core/commands/clear.hpp
@@ -1,0 +1,27 @@
+/**
+ * clear.hpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_COMMANDS_CLEAR_HPP_
+#define CORE_COMMANDS_CLEAR_HPP_
+
+#include <core/commands/command.hpp>
+
+namespace cassio {
+namespace kernel {
+
+class ClearCommand : public Command {
+public:
+    ClearCommand();
+    bool execute(const char** args, usize argc) override;
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_COMMANDS_CLEAR_HPP_

--- a/include/core/commands/command.hpp
+++ b/include/core/commands/command.hpp
@@ -1,0 +1,59 @@
+/**
+ * command.hpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_COMMANDS_COMMAND_HPP_
+#define CORE_COMMANDS_COMMAND_HPP_
+
+#include <common/types.hpp>
+
+namespace cassio {
+namespace kernel {
+
+constexpr u8 MAX_COMMANDS = 32;
+
+/**
+ * @brief Base class for shell commands.
+ *
+ * Commands self-register into a static registry at construction time
+ * (via global constructors). The shell looks up commands by name and
+ * calls execute().
+ *
+ */
+class Command {
+private:
+    static Command* registry[MAX_COMMANDS];
+    static u8 count;
+
+    const char* name;
+    const char* description;
+
+public:
+    Command(const char* name, const char* description);
+    ~Command() = default;
+
+    const char* getName() const;
+    const char* getDescription() const;
+
+    /**
+     * @brief Runs the command with the given arguments.
+     *
+     * @return true if the shell should continue, false to exit.
+     *
+     */
+    virtual bool execute(const char** args, usize argc) = 0;
+
+    static Command* find(const char* name);
+    static Command** getRegistry();
+    static u8 getCount();
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_COMMANDS_COMMAND_HPP_

--- a/include/core/commands/help.hpp
+++ b/include/core/commands/help.hpp
@@ -1,0 +1,27 @@
+/**
+ * help.hpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_COMMANDS_HELP_HPP_
+#define CORE_COMMANDS_HELP_HPP_
+
+#include <core/commands/command.hpp>
+
+namespace cassio {
+namespace kernel {
+
+class HelpCommand : public Command {
+public:
+    HelpCommand();
+    bool execute(const char** args, usize argc) override;
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_COMMANDS_HELP_HPP_

--- a/include/core/commands/mem.hpp
+++ b/include/core/commands/mem.hpp
@@ -1,0 +1,27 @@
+/**
+ * mem.hpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_COMMANDS_MEM_HPP_
+#define CORE_COMMANDS_MEM_HPP_
+
+#include <core/commands/command.hpp>
+
+namespace cassio {
+namespace kernel {
+
+class MemCommand : public Command {
+public:
+    MemCommand();
+    bool execute(const char** args, usize argc) override;
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_COMMANDS_MEM_HPP_

--- a/include/core/commands/reboot.hpp
+++ b/include/core/commands/reboot.hpp
@@ -1,0 +1,27 @@
+/**
+ * reboot.hpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_COMMANDS_REBOOT_HPP_
+#define CORE_COMMANDS_REBOOT_HPP_
+
+#include <core/commands/command.hpp>
+
+namespace cassio {
+namespace kernel {
+
+class RebootCommand : public Command {
+public:
+    RebootCommand();
+    bool execute(const char** args, usize argc) override;
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_COMMANDS_REBOOT_HPP_

--- a/include/core/commands/shutdown.hpp
+++ b/include/core/commands/shutdown.hpp
@@ -1,0 +1,27 @@
+/**
+ * shutdown.hpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_COMMANDS_SHUTDOWN_HPP_
+#define CORE_COMMANDS_SHUTDOWN_HPP_
+
+#include <core/commands/command.hpp>
+
+namespace cassio {
+namespace kernel {
+
+class ShutdownCommand : public Command {
+public:
+    ShutdownCommand();
+    bool execute(const char** args, usize argc) override;
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_COMMANDS_SHUTDOWN_HPP_

--- a/include/core/shell.hpp
+++ b/include/core/shell.hpp
@@ -18,12 +18,14 @@ namespace cassio {
 namespace kernel {
 
 constexpr u8 SHELL_MAX_INPUT = 78;
+constexpr u8 SHELL_MAX_ARGS = 16;
 
 /**
- * @brief Simple command shell that provides a `$ ` prompt and built-in commands.
+ * @brief Simple command shell that provides a `$ ` prompt and dispatches
+ * commands via the Command registry.
  *
  * Handles line editing with cursor movement (left/right arrows, backspace)
- * and dispatches entered commands: shutdown, help, clear.
+ * and splits input into arguments for command execution.
  *
  */
 class Shell : public drivers::KeyboardEventHandler {
@@ -40,8 +42,6 @@ private:
     void printPrompt();
     void redrawLine();
     void execute();
-
-    bool streq(const char* a, const char* b);
 
 public:
     Shell();

--- a/src/core/commands/clear.cpp
+++ b/src/core/commands/clear.cpp
@@ -1,0 +1,24 @@
+/**
+ * clear.cpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/commands/clear.hpp"
+#include "hardware/terminal.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::hardware;
+
+static ClearCommand instance;
+
+ClearCommand::ClearCommand() : Command("clear", "Clear the screen") {}
+
+bool ClearCommand::execute(const char** args, usize argc) {
+    VgaTerminal::getTerminal().clear();
+    return true;
+}

--- a/src/core/commands/command.cpp
+++ b/src/core/commands/command.cpp
@@ -1,0 +1,56 @@
+/**
+ * command.cpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/commands/command.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+
+Command* Command::registry[MAX_COMMANDS] = {};
+u8 Command::count = 0;
+
+Command::Command(const char* name, const char* description)
+    : name(name), description(description) {
+    if (count < MAX_COMMANDS) {
+        registry[count++] = this;
+    }
+}
+
+const char* Command::getName() const {
+    return name;
+}
+
+const char* Command::getDescription() const {
+    return description;
+}
+
+Command* Command::find(const char* name) {
+    for (u8 i = 0; i < count; ++i) {
+        const char* a = name;
+        const char* b = registry[i]->name;
+        bool match = true;
+        u32 j = 0;
+        while (a[j] != '\0' && b[j] != '\0') {
+            if (a[j] != b[j]) { match = false; break; }
+            ++j;
+        }
+        if (match && a[j] == b[j]) {
+            return registry[i];
+        }
+    }
+    return nullptr;
+}
+
+Command** Command::getRegistry() {
+    return registry;
+}
+
+u8 Command::getCount() {
+    return count;
+}

--- a/src/core/commands/help.cpp
+++ b/src/core/commands/help.cpp
@@ -1,0 +1,45 @@
+/**
+ * help.cpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/commands/help.hpp"
+#include "hardware/terminal.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::hardware;
+
+static HelpCommand instance;
+
+HelpCommand::HelpCommand() : Command("help", "Show available commands") {}
+
+bool HelpCommand::execute(const char** args, usize argc) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+    vga.print("Available commands:\n");
+
+    Command** cmds = Command::getRegistry();
+    u8 count = Command::getCount();
+    for (u8 i = 0; i < count; ++i) {
+        vga.print("  ");
+        vga.print(cmds[i]->getName());
+
+        // Pad to 12 characters for alignment.
+        usize len = 0;
+        const char* n = cmds[i]->getName();
+        while (n[len] != '\0') ++len;
+        for (usize j = len; j < 12; ++j) {
+            vga.putchar(' ');
+        }
+
+        vga.print("- ");
+        vga.print(cmds[i]->getDescription());
+        vga.putchar('\n');
+    }
+
+    return true;
+}

--- a/src/core/commands/mem.cpp
+++ b/src/core/commands/mem.cpp
@@ -1,0 +1,48 @@
+/**
+ * mem.cpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/commands/mem.hpp"
+#include "hardware/terminal.hpp"
+#include "memory/physical.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::hardware;
+using namespace cassio::memory;
+
+static MemCommand instance;
+
+MemCommand::MemCommand() : Command("mem", "Show memory statistics") {}
+
+bool MemCommand::execute(const char** args, usize argc) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+    PhysicalMemoryManager& pmm = PhysicalMemoryManager::getManager();
+    u32 free = pmm.getFreeFrames();
+    u32 total = pmm.getTotalFrames();
+    u32 used = pmm.getUsedFrames();
+
+    vga.print("Physical memory:\n");
+    vga.print("  Total: ");
+    vga.print_dec(total * 4);
+    vga.print(" KiB (");
+    vga.print_dec(total);
+    vga.print(" frames)\n");
+    vga.print("  Used:  ");
+    vga.print_dec(used * 4);
+    vga.print(" KiB (");
+    vga.print_dec(used);
+    vga.print(" frames)\n");
+    vga.print("  Free:  ");
+    vga.print_dec(free * 4);
+    vga.print(" KiB (");
+    vga.print_dec(free);
+    vga.print(" frames)\n");
+
+    return true;
+}

--- a/src/core/commands/reboot.cpp
+++ b/src/core/commands/reboot.cpp
@@ -1,0 +1,27 @@
+/**
+ * reboot.cpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/commands/reboot.hpp"
+#include "hardware/terminal.hpp"
+#include "hardware/port.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::hardware;
+
+static RebootCommand instance;
+
+RebootCommand::RebootCommand() : Command("reboot", "Reboot the system") {}
+
+bool RebootCommand::execute(const char** args, usize argc) {
+    VgaTerminal::getTerminal().print("Rebooting...\n");
+    Port<u8> cmd(PortType::KeyboardControllerCommand);
+    cmd.write(0xFE);
+    return false;
+}

--- a/src/core/commands/shutdown.cpp
+++ b/src/core/commands/shutdown.cpp
@@ -1,0 +1,24 @@
+/**
+ * shutdown.cpp
+ *
+ * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/commands/shutdown.hpp"
+#include "hardware/terminal.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::hardware;
+
+static ShutdownCommand instance;
+
+ShutdownCommand::ShutdownCommand() : Command("shutdown", "Halt the system") {}
+
+bool ShutdownCommand::execute(const char** args, usize argc) {
+    VgaTerminal::getTerminal().print("Shutting down...\n");
+    return false;
+}

--- a/src/core/shell.cpp
+++ b/src/core/shell.cpp
@@ -8,13 +8,12 @@
  */
 
 #include "core/shell.hpp"
-#include "memory/physical.hpp"
+#include "core/commands/command.hpp"
 
 using namespace cassio;
 using namespace cassio::kernel;
 using namespace cassio::drivers;
 using namespace cassio::hardware;
-using namespace cassio::memory;
 
 Shell::Shell()
     : vga(VgaTerminal::getTerminal()),
@@ -31,15 +30,6 @@ void Shell::run() {
     while (running) {
         asm volatile("hlt");
     }
-}
-
-bool Shell::streq(const char* a, const char* b) {
-    u32 i = 0;
-    while (a[i] != '\0' && b[i] != '\0') {
-        if (a[i] != b[i]) return false;
-        ++i;
-    }
-    return a[i] == b[i];
 }
 
 void Shell::printPrompt() {
@@ -74,59 +64,38 @@ void Shell::execute() {
         return;
     }
 
-    if (streq(buffer, "shutdown")) {
-        vga.print("Shutting down...\n");
-        running = false;
-        return;
+    // Split buffer into arguments by replacing spaces with null bytes.
+    const char* args[SHELL_MAX_ARGS];
+    usize argc = 0;
+    bool in_word = false;
+
+    for (u8 i = 0; i <= length; ++i) {
+        if (buffer[i] == ' ' || buffer[i] == '\0') {
+            buffer[i] = '\0';
+            in_word = false;
+        } else if (!in_word) {
+            if (argc < SHELL_MAX_ARGS) {
+                args[argc++] = &buffer[i];
+            }
+            in_word = true;
+        }
     }
 
-    if (streq(buffer, "reboot")) {
-        vga.print("Rebooting...\n");
-        Port<u8> cmd(PortType::KeyboardControllerCommand);
-        cmd.write(0xFE);
-        return;
-    }
-
-    if (streq(buffer, "help")) {
-        vga.print("Available commands:\n");
-        vga.print("  clear     - Clear the screen\n");
-        vga.print("  help      - Show this message\n");
-        vga.print("  mem       - Show memory statistics\n");
-        vga.print("  reboot    - Reboot the system\n");
-        vga.print("  shutdown  - Halt the system\n");
-    } else if (streq(buffer, "mem")) {
-        PhysicalMemoryManager& pmm = PhysicalMemoryManager::getManager();
-        u32 free = pmm.getFreeFrames();
-        u32 total = pmm.getTotalFrames();
-        u32 used = pmm.getUsedFrames();
-
-        vga.print("Physical memory:\n");
-        vga.print("  Total: ");
-        vga.print_dec(total * 4);
-        vga.print(" KiB (");
-        vga.print_dec(total);
-        vga.print(" frames)\n");
-        vga.print("  Used:  ");
-        vga.print_dec(used * 4);
-        vga.print(" KiB (");
-        vga.print_dec(used);
-        vga.print(" frames)\n");
-        vga.print("  Free:  ");
-        vga.print_dec(free * 4);
-        vga.print(" KiB (");
-        vga.print_dec(free);
-        vga.print(" frames)\n");
-    } else if (streq(buffer, "clear")) {
-        vga.clear();
+    Command* cmd = Command::find(args[0]);
+    if (cmd) {
+        running = cmd->execute(args, argc);
     } else {
         vga.print("Unknown command: ");
-        vga.print(buffer);
+        vga.print(args[0]);
         vga.putchar('\n');
     }
 
     length = 0;
     cursor = 0;
-    printPrompt();
+
+    if (running) {
+        printPrompt();
+    }
 }
 
 void Shell::OnKeyDown(KeyCode key) {

--- a/tests/test_commands.cpp
+++ b/tests/test_commands.cpp
@@ -1,0 +1,63 @@
+#include <core/commands/command.hpp>
+#include "test.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+
+TEST(command_registry_has_commands) {
+    ASSERT(Command::getCount() > 0);
+}
+
+TEST(command_registry_count_matches_expected) {
+    // Five built-in commands: help, clear, mem, reboot, shutdown.
+    ASSERT_EQ(Command::getCount(), 5);
+}
+
+TEST(command_find_existing) {
+    Command* cmd = Command::find("help");
+    ASSERT(cmd != nullptr);
+}
+
+TEST(command_find_nonexistent) {
+    Command* cmd = Command::find("nonexistent");
+    ASSERT(cmd == nullptr);
+}
+
+TEST(command_find_each_builtin) {
+    ASSERT(Command::find("help") != nullptr);
+    ASSERT(Command::find("clear") != nullptr);
+    ASSERT(Command::find("mem") != nullptr);
+    ASSERT(Command::find("reboot") != nullptr);
+    ASSERT(Command::find("shutdown") != nullptr);
+}
+
+TEST(command_name_matches) {
+    Command* cmd = Command::find("help");
+    ASSERT(cmd != nullptr);
+
+    const char* name = cmd->getName();
+    const char* expected = "help";
+    u32 i = 0;
+    while (name[i] != '\0' && expected[i] != '\0') {
+        ASSERT_EQ((u32)name[i], (u32)expected[i]);
+        ++i;
+    }
+    ASSERT_EQ((u32)name[i], (u32)expected[i]);
+}
+
+TEST(command_description_not_null) {
+    Command* cmd = Command::find("clear");
+    ASSERT(cmd != nullptr);
+    ASSERT(cmd->getDescription() != nullptr);
+}
+
+TEST(command_find_partial_no_match) {
+    // "hel" should not match "help".
+    Command* cmd = Command::find("hel");
+    ASSERT(cmd == nullptr);
+}
+
+TEST(command_find_empty_string) {
+    Command* cmd = Command::find("");
+    ASSERT(cmd == nullptr);
+}


### PR DESCRIPTION
## Summary

- Add `Command` base class with self-registering static registry (max 32 commands)
- Migrate all 5 existing commands (help, clear, mem, reboot, shutdown) to individual `Command` subclasses under `src/core/commands/`
- Refactor shell to split input into args and dispatch via `Command::find()`, replacing the if-chain
- Modernize Makefile to auto-discover source files via `find` instead of manual object lists
- Add 9 tests for command registration, lookup, and edge cases (68 total pass)

Closes #48

## Test plan

- [x] All 68 tests pass (`make test`)
- [x] Visual verification: `help` command lists all commands with descriptions
- [x] Clean build from scratch works