### PR TITLE
#45: Update copyright year from 2019 to 2019-2026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+# Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Giovanni Giacomo <ggiacomo@furg.br>
+Copyright (c) 2019-2026 Giovanni Giacomo <ggiacomo@furg.br>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+# Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 

--- a/include/common/types.hpp
+++ b/include/common/types.hpp
@@ -1,7 +1,7 @@
 /**
  * types.hpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/core/commands/clear.hpp
+++ b/include/core/commands/clear.hpp
@@ -1,7 +1,7 @@
 /**
  * clear.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/core/commands/command.hpp
+++ b/include/core/commands/command.hpp
@@ -1,7 +1,7 @@
 /**
  * command.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/core/commands/help.hpp
+++ b/include/core/commands/help.hpp
@@ -1,7 +1,7 @@
 /**
  * help.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/core/commands/mem.hpp
+++ b/include/core/commands/mem.hpp
@@ -1,7 +1,7 @@
 /**
  * mem.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/core/commands/reboot.hpp
+++ b/include/core/commands/reboot.hpp
@@ -1,7 +1,7 @@
 /**
  * reboot.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/core/commands/shutdown.hpp
+++ b/include/core/commands/shutdown.hpp
@@ -1,7 +1,7 @@
 /**
  * shutdown.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/core/gdt.hpp
+++ b/include/core/gdt.hpp
@@ -1,7 +1,7 @@
 /**
  * gdt.hpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/core/kernel.hpp
+++ b/include/core/kernel.hpp
@@ -1,7 +1,7 @@
 /**
  * kernel.hpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/core/shell.hpp
+++ b/include/core/shell.hpp
@@ -1,7 +1,7 @@
 /**
  * shell.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/drivers/keyboard.hpp
+++ b/include/drivers/keyboard.hpp
@@ -1,7 +1,7 @@
 /**
  * keyboard.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/drivers/mouse.hpp
+++ b/include/drivers/mouse.hpp
@@ -1,7 +1,7 @@
 /**
  * mouse.hpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/hardware/driver.hpp
+++ b/include/hardware/driver.hpp
@@ -1,7 +1,7 @@
 /**
  * driver.hpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/hardware/interrupt.hpp
+++ b/include/hardware/interrupt.hpp
@@ -1,7 +1,7 @@
 /**
  * interrupt.hpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/hardware/port.hpp
+++ b/include/hardware/port.hpp
@@ -1,7 +1,7 @@
 /**
  * port.hpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/hardware/terminal.hpp
+++ b/include/hardware/terminal.hpp
@@ -1,7 +1,7 @@
 /**
  * terminal.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/memory/heap.hpp
+++ b/include/memory/heap.hpp
@@ -1,7 +1,7 @@
 /**
  * heap.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/memory/multiboot.hpp
+++ b/include/memory/multiboot.hpp
@@ -1,7 +1,7 @@
 /**
  * multiboot.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/memory/paging.hpp
+++ b/include/memory/paging.hpp
@@ -1,7 +1,7 @@
 /**
  * paging.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/include/memory/physical.hpp
+++ b/include/memory/physical.hpp
@@ -1,7 +1,7 @@
 /**
  * physical.hpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/core/commands/clear.cpp
+++ b/src/core/commands/clear.cpp
@@ -1,7 +1,7 @@
 /**
  * clear.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/core/commands/command.cpp
+++ b/src/core/commands/command.cpp
@@ -1,7 +1,7 @@
 /**
  * command.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/core/commands/help.cpp
+++ b/src/core/commands/help.cpp
@@ -1,7 +1,7 @@
 /**
  * help.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/core/commands/mem.cpp
+++ b/src/core/commands/mem.cpp
@@ -1,7 +1,7 @@
 /**
  * mem.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/core/commands/reboot.cpp
+++ b/src/core/commands/reboot.cpp
@@ -1,7 +1,7 @@
 /**
  * reboot.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/core/commands/shutdown.cpp
+++ b/src/core/commands/shutdown.cpp
@@ -1,7 +1,7 @@
 /**
  * shutdown.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/core/gdt.cpp
+++ b/src/core/gdt.cpp
@@ -1,7 +1,7 @@
 /**
  * gdt.cpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/core/kernel.cpp
+++ b/src/core/kernel.cpp
@@ -1,7 +1,7 @@
 /**
  * kernel.cpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/core/loader.s
+++ b/src/core/loader.s
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+# Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 

--- a/src/core/shell.cpp
+++ b/src/core/shell.cpp
@@ -1,7 +1,7 @@
 /**
  * shell.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/drivers/keyboard.cpp
+++ b/src/drivers/keyboard.cpp
@@ -1,7 +1,7 @@
 /**
  * keyboard.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/drivers/mouse.cpp
+++ b/src/drivers/mouse.cpp
@@ -1,7 +1,7 @@
 /**
  * mouse.cpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/hardware/driver.cpp
+++ b/src/hardware/driver.cpp
@@ -1,7 +1,7 @@
 /**
  * driver.cpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/hardware/interrupt.cpp
+++ b/src/hardware/interrupt.cpp
@@ -1,7 +1,7 @@
 /**
  * interrupt.cpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/hardware/port.cpp
+++ b/src/hardware/port.cpp
@@ -1,7 +1,7 @@
 /**
  * port.cpp
  * 
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/hardware/stub.s
+++ b/src/hardware/stub.s
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+# Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 

--- a/src/hardware/terminal.cpp
+++ b/src/hardware/terminal.cpp
@@ -1,7 +1,7 @@
 /**
  * terminal.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -1,7 +1,7 @@
 /**
  * linker.ld
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/memory/heap.cpp
+++ b/src/memory/heap.cpp
@@ -1,7 +1,7 @@
 /**
  * heap.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/memory/operators.cpp
+++ b/src/memory/operators.cpp
@@ -1,7 +1,7 @@
 /**
  * operators.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/memory/paging.cpp
+++ b/src/memory/paging.cpp
@@ -1,7 +1,7 @@
 /**
  * paging.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *

--- a/src/memory/physical.cpp
+++ b/src/memory/physical.cpp
@@ -1,7 +1,7 @@
 /**
  * physical.cpp
  *
- * Copyright (c) 2019 Giovanni Giacomo. All Rights Reserved.
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
  * Use of this source code is governed by a MIT-style
  * license that can be found in the LICENSE file.
  *


### PR DESCRIPTION
## Summary

- Update copyright headers across all 45 source files from `2019` to `2019-2026`

Closes #45

## Test plan

- [x] All 68 tests pass (`make test`)
- [x] Clean build succeeds