### PR TITLE
#52: Add file content commands: cat, write, echo

### DIFF
--- a/include/core/commands/cat.hpp
+++ b/include/core/commands/cat.hpp
@@ -1,0 +1,28 @@
+/**
+ * cat.hpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_COMMANDS_CAT_HPP_
+#define CORE_COMMANDS_CAT_HPP_
+
+#include <core/commands/command.hpp>
+
+namespace cassio {
+namespace kernel {
+
+class CatCommand : public Command {
+public:
+    CatCommand();
+    bool execute(const char** args, usize argc,
+                 filesystem::FileNode*& cwd) override;
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_COMMANDS_CAT_HPP_

--- a/include/core/commands/echo.hpp
+++ b/include/core/commands/echo.hpp
@@ -1,0 +1,28 @@
+/**
+ * echo.hpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_COMMANDS_ECHO_HPP_
+#define CORE_COMMANDS_ECHO_HPP_
+
+#include <core/commands/command.hpp>
+
+namespace cassio {
+namespace kernel {
+
+class EchoCommand : public Command {
+public:
+    EchoCommand();
+    bool execute(const char** args, usize argc,
+                 filesystem::FileNode*& cwd) override;
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_COMMANDS_ECHO_HPP_

--- a/include/core/commands/write.hpp
+++ b/include/core/commands/write.hpp
@@ -1,0 +1,28 @@
+/**
+ * write.hpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_COMMANDS_WRITE_HPP_
+#define CORE_COMMANDS_WRITE_HPP_
+
+#include <core/commands/command.hpp>
+
+namespace cassio {
+namespace kernel {
+
+class WriteCommand : public Command {
+public:
+    WriteCommand();
+    bool execute(const char** args, usize argc,
+                 filesystem::FileNode*& cwd) override;
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_COMMANDS_WRITE_HPP_

--- a/src/core/commands/cat.cpp
+++ b/src/core/commands/cat.cpp
@@ -1,0 +1,57 @@
+/**
+ * cat.cpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/commands/cat.hpp"
+#include "filesystem/filesystem.hpp"
+#include "hardware/terminal.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::filesystem;
+using namespace cassio::hardware;
+
+static CatCommand instance;
+
+CatCommand::CatCommand() : Command("cat", "Print file contents") {}
+
+bool CatCommand::execute(const char** args, usize argc,
+                         FileNode*& cwd) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+
+    if (argc < 2) {
+        vga.print("cat: missing operand\n");
+        return true;
+    }
+
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* target = fs.resolve(args[1], cwd);
+    if (target == nullptr) {
+        vga.print("cat: no such file: ");
+        vga.print(args[1]);
+        vga.putchar('\n');
+        return true;
+    }
+
+    if (target->type != FileNodeType::File) {
+        vga.print("cat: not a file: ");
+        vga.print(args[1]);
+        vga.putchar('\n');
+        return true;
+    }
+
+    for (usize i = 0; i < target->size; ++i) {
+        vga.putchar(static_cast<char>(target->data[i]));
+    }
+
+    if (target->size > 0) {
+        vga.putchar('\n');
+    }
+
+    return true;
+}

--- a/src/core/commands/echo.cpp
+++ b/src/core/commands/echo.cpp
@@ -1,0 +1,33 @@
+/**
+ * echo.cpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/commands/echo.hpp"
+#include "hardware/terminal.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::filesystem;
+using namespace cassio::hardware;
+
+static EchoCommand instance;
+
+EchoCommand::EchoCommand() : Command("echo", "Print text to screen") {}
+
+bool EchoCommand::execute(const char** args, usize argc,
+                          FileNode*& cwd) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+
+    for (usize i = 1; i < argc; ++i) {
+        if (i > 1) vga.putchar(' ');
+        vga.print(args[i]);
+    }
+
+    vga.putchar('\n');
+    return true;
+}

--- a/src/core/commands/write.cpp
+++ b/src/core/commands/write.cpp
@@ -1,0 +1,70 @@
+/**
+ * write.cpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/commands/write.hpp"
+#include "common/string.hpp"
+#include "filesystem/filesystem.hpp"
+#include "hardware/terminal.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::filesystem;
+using namespace cassio::hardware;
+
+static WriteCommand instance;
+
+WriteCommand::WriteCommand() : Command("write", "Write text to a file") {}
+
+bool WriteCommand::execute(const char** args, usize argc,
+                           FileNode*& cwd) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+
+    if (argc < 3) {
+        vga.print("write: usage: write <filename> <text>\n");
+        return true;
+    }
+
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* target = fs.resolve(args[1], cwd);
+    if (target == nullptr) {
+        vga.print("write: no such file: ");
+        vga.print(args[1]);
+        vga.putchar('\n');
+        return true;
+    }
+
+    if (target->type != FileNodeType::File) {
+        vga.print("write: not a file: ");
+        vga.print(args[1]);
+        vga.putchar('\n');
+        return true;
+    }
+
+    // Compute total text length (args[2..argc-1] joined by spaces).
+    usize total = 0;
+    for (usize i = 2; i < argc; ++i) {
+        if (i > 2) ++total; // space separator
+        total += strlen(args[i]);
+    }
+
+    // Build the text buffer.
+    u8 buf[256];
+    usize pos = 0;
+    for (usize i = 2; i < argc && pos < sizeof(buf); ++i) {
+        if (i > 2 && pos < sizeof(buf)) {
+            buf[pos++] = ' ';
+        }
+        for (usize j = 0; args[i][j] != '\0' && pos < sizeof(buf); ++j) {
+            buf[pos++] = static_cast<u8>(args[i][j]);
+        }
+    }
+
+    fs.write(target, buf, pos);
+    return true;
+}

--- a/tests/test_commands.cpp
+++ b/tests/test_commands.cpp
@@ -9,8 +9,8 @@ TEST(command_registry_has_commands) {
 }
 
 TEST(command_registry_count_matches_expected) {
-    // Twelve built-in commands.
-    ASSERT_EQ(Command::getCount(), 12);
+    // Fifteen built-in commands.
+    ASSERT_EQ(Command::getCount(), 15);
 }
 
 TEST(command_find_existing) {
@@ -36,6 +36,9 @@ TEST(command_find_each_builtin) {
     ASSERT(Command::find("rmdir") != nullptr);
     ASSERT(Command::find("touch") != nullptr);
     ASSERT(Command::find("rm") != nullptr);
+    ASSERT(Command::find("cat") != nullptr);
+    ASSERT(Command::find("write") != nullptr);
+    ASSERT(Command::find("echo") != nullptr);
 }
 
 TEST(command_name_matches) {

--- a/tests/test_filecontent.cpp
+++ b/tests/test_filecontent.cpp
@@ -1,0 +1,182 @@
+#include <core/commands/command.hpp>
+#include <filesystem/filesystem.hpp>
+#include <common/string.hpp>
+#include "test.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::filesystem;
+
+// --- cat ---
+
+TEST(cat_prints_file_contents) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* file = fs.createFile("cat_test.txt", cwd);
+    const u8 data[] = {'h', 'e', 'l', 'l', 'o'};
+    fs.write(file, data, 5);
+
+    Command* cmd = Command::find("cat");
+    ASSERT(cmd != nullptr);
+
+    const char* args[] = {"cat", "cat_test.txt"};
+    ASSERT(cmd->execute(args, 2, cwd));
+
+    // Verify file still exists and data unchanged.
+    ASSERT_EQ(file->size, 5);
+    ASSERT_EQ((u32)file->data[0], (u32)'h');
+
+    fs.remove(file);
+}
+
+TEST(cat_empty_file) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* file = fs.createFile("cat_empty.txt", cwd);
+
+    Command* cmd = Command::find("cat");
+    const char* args[] = {"cat", "cat_empty.txt"};
+    ASSERT(cmd->execute(args, 2, cwd));
+
+    fs.remove(file);
+}
+
+TEST(cat_missing_operand) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+
+    Command* cmd = Command::find("cat");
+    const char* args[] = {"cat"};
+    ASSERT(cmd->execute(args, 1, cwd));
+}
+
+TEST(cat_nonexistent_file) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+
+    Command* cmd = Command::find("cat");
+    const char* args[] = {"cat", "no_such_file.txt"};
+    ASSERT(cmd->execute(args, 2, cwd));
+}
+
+TEST(cat_on_directory_fails) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* dir = fs.createDirectory("cat_dir", cwd);
+
+    Command* cmd = Command::find("cat");
+    const char* args[] = {"cat", "cat_dir"};
+    ASSERT(cmd->execute(args, 2, cwd));
+
+    fs.remove(dir);
+}
+
+// --- write ---
+
+TEST(write_writes_text_to_file) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* file = fs.createFile("wr_test.txt", cwd);
+
+    Command* cmd = Command::find("write");
+    ASSERT(cmd != nullptr);
+
+    const char* args[] = {"write", "wr_test.txt", "hello"};
+    cmd->execute(args, 3, cwd);
+
+    ASSERT_EQ(file->size, 5);
+    ASSERT_EQ((u32)file->data[0], (u32)'h');
+    ASSERT_EQ((u32)file->data[4], (u32)'o');
+
+    fs.remove(file);
+}
+
+TEST(write_joins_multiple_args) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* file = fs.createFile("wr_multi.txt", cwd);
+
+    Command* cmd = Command::find("write");
+    const char* args[] = {"write", "wr_multi.txt", "hello", "world"};
+    cmd->execute(args, 4, cwd);
+
+    // "hello world" = 11 bytes
+    ASSERT_EQ(file->size, 11);
+    ASSERT_EQ((u32)file->data[5], (u32)' ');
+    ASSERT_EQ((u32)file->data[6], (u32)'w');
+
+    fs.remove(file);
+}
+
+TEST(write_overwrites_existing_content) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* file = fs.createFile("wr_overwrite.txt", cwd);
+
+    const u8 old_data[] = {'o', 'l', 'd'};
+    fs.write(file, old_data, 3);
+
+    Command* cmd = Command::find("write");
+    const char* args[] = {"write", "wr_overwrite.txt", "new"};
+    cmd->execute(args, 3, cwd);
+
+    ASSERT_EQ(file->size, 3);
+    ASSERT_EQ((u32)file->data[0], (u32)'n');
+
+    fs.remove(file);
+}
+
+TEST(write_missing_args) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+
+    Command* cmd = Command::find("write");
+    const char* args1[] = {"write"};
+    ASSERT(cmd->execute(args1, 1, cwd));
+
+    const char* args2[] = {"write", "somefile"};
+    ASSERT(cmd->execute(args2, 2, cwd));
+}
+
+TEST(write_nonexistent_file) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+
+    Command* cmd = Command::find("write");
+    const char* args[] = {"write", "no_such.txt", "data"};
+    ASSERT(cmd->execute(args, 3, cwd));
+}
+
+TEST(write_on_directory_fails) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* dir = fs.createDirectory("wr_dir", cwd);
+
+    Command* cmd = Command::find("write");
+    const char* args[] = {"write", "wr_dir", "data"};
+    ASSERT(cmd->execute(args, 3, cwd));
+
+    fs.remove(dir);
+}
+
+// --- echo ---
+
+TEST(echo_no_args_prints_newline) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+
+    Command* cmd = Command::find("echo");
+    ASSERT(cmd != nullptr);
+
+    const char* args[] = {"echo"};
+    ASSERT(cmd->execute(args, 1, cwd));
+}
+
+TEST(echo_prints_text) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+
+    Command* cmd = Command::find("echo");
+    const char* args[] = {"echo", "hello", "world"};
+    ASSERT(cmd->execute(args, 3, cwd));
+}


### PR DESCRIPTION
## Summary
- `cat <filename>` -- prints file contents to screen
- `write <filename> <text>` -- overwrites file with text (joins all args after filename with spaces)
- `echo <text>` -- prints text to screen (joins all args with spaces)
- Tests for all three commands (cat: 5 tests, write: 6 tests, echo: 2 tests)

Closes #52

## Test plan
- [x] `make test` passes (135/135, including 13 new tests)
- [x] Manual test: `touch foo.txt && write foo.txt hello world && cat foo.txt` shows "hello world"
- [x] Manual test: `echo hello world` prints "hello world"
- [x] Manual test: error cases (cat on directory, write to nonexistent file, etc.)