### PR TITLE
#53: Add file operation commands: mv, cp

### DIFF
--- a/include/core/commands/cp.hpp
+++ b/include/core/commands/cp.hpp
@@ -1,0 +1,28 @@
+/**
+ * cp.hpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_COMMANDS_CP_HPP_
+#define CORE_COMMANDS_CP_HPP_
+
+#include <core/commands/command.hpp>
+
+namespace cassio {
+namespace kernel {
+
+class CpCommand : public Command {
+public:
+    CpCommand();
+    bool execute(const char** args, usize argc,
+                 filesystem::FileNode*& cwd) override;
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_COMMANDS_CP_HPP_

--- a/include/core/commands/mv.hpp
+++ b/include/core/commands/mv.hpp
@@ -1,0 +1,28 @@
+/**
+ * mv.hpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_COMMANDS_MV_HPP_
+#define CORE_COMMANDS_MV_HPP_
+
+#include <core/commands/command.hpp>
+
+namespace cassio {
+namespace kernel {
+
+class MvCommand : public Command {
+public:
+    MvCommand();
+    bool execute(const char** args, usize argc,
+                 filesystem::FileNode*& cwd) override;
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_COMMANDS_MV_HPP_

--- a/src/core/commands/cp.cpp
+++ b/src/core/commands/cp.cpp
@@ -1,0 +1,55 @@
+/**
+ * cp.cpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/commands/cp.hpp"
+#include "filesystem/filesystem.hpp"
+#include "hardware/terminal.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::filesystem;
+using namespace cassio::hardware;
+
+static CpCommand instance;
+
+CpCommand::CpCommand() : Command("cp", "Copy a file") {}
+
+bool CpCommand::execute(const char** args, usize argc,
+                        FileNode*& cwd) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+
+    if (argc < 3) {
+        vga.print("cp: usage: cp <source> <destination>\n");
+        return true;
+    }
+
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* source = fs.resolve(args[1], cwd);
+    if (source == nullptr) {
+        vga.print("cp: no such file: ");
+        vga.print(args[1]);
+        vga.putchar('\n');
+        return true;
+    }
+
+    if (source->type != FileNodeType::File) {
+        vga.print("cp: not a file: ");
+        vga.print(args[1]);
+        vga.putchar('\n');
+        return true;
+    }
+
+    if (fs.copy(source, args[2], cwd) == nullptr) {
+        vga.print("cp: cannot copy to: ");
+        vga.print(args[2]);
+        vga.putchar('\n');
+    }
+
+    return true;
+}

--- a/src/core/commands/mv.cpp
+++ b/src/core/commands/mv.cpp
@@ -1,0 +1,48 @@
+/**
+ * mv.cpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/commands/mv.hpp"
+#include "filesystem/filesystem.hpp"
+#include "hardware/terminal.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::filesystem;
+using namespace cassio::hardware;
+
+static MvCommand instance;
+
+MvCommand::MvCommand() : Command("mv", "Move or rename a file or directory") {}
+
+bool MvCommand::execute(const char** args, usize argc,
+                        FileNode*& cwd) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+
+    if (argc < 3) {
+        vga.print("mv: usage: mv <source> <destination>\n");
+        return true;
+    }
+
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* source = fs.resolve(args[1], cwd);
+    if (source == nullptr) {
+        vga.print("mv: no such file or directory: ");
+        vga.print(args[1]);
+        vga.putchar('\n');
+        return true;
+    }
+
+    if (!fs.move(source, args[2], cwd)) {
+        vga.print("mv: cannot move to: ");
+        vga.print(args[2]);
+        vga.putchar('\n');
+    }
+
+    return true;
+}

--- a/tests/test_commands.cpp
+++ b/tests/test_commands.cpp
@@ -9,8 +9,8 @@ TEST(command_registry_has_commands) {
 }
 
 TEST(command_registry_count_matches_expected) {
-    // Fifteen built-in commands.
-    ASSERT_EQ(Command::getCount(), 15);
+    // Seventeen built-in commands.
+    ASSERT_EQ(Command::getCount(), 17);
 }
 
 TEST(command_find_existing) {
@@ -39,6 +39,8 @@ TEST(command_find_each_builtin) {
     ASSERT(Command::find("cat") != nullptr);
     ASSERT(Command::find("write") != nullptr);
     ASSERT(Command::find("echo") != nullptr);
+    ASSERT(Command::find("mv") != nullptr);
+    ASSERT(Command::find("cp") != nullptr);
 }
 
 TEST(command_name_matches) {

--- a/tests/test_fileoperation.cpp
+++ b/tests/test_fileoperation.cpp
@@ -1,0 +1,173 @@
+#include <core/commands/command.hpp>
+#include <filesystem/filesystem.hpp>
+#include <common/string.hpp>
+#include "test.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::filesystem;
+
+// --- mv ---
+
+TEST(mv_renames_file) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* file = fs.createFile("mv_src.txt", cwd);
+
+    Command* cmd = Command::find("mv");
+    ASSERT(cmd != nullptr);
+
+    const char* args[] = {"mv", "mv_src.txt", "mv_dst.txt"};
+    cmd->execute(args, 3, cwd);
+
+    ASSERT(fs.resolve("mv_src.txt", cwd) == nullptr);
+    FileNode* moved = fs.resolve("mv_dst.txt", cwd);
+    ASSERT(moved != nullptr);
+    ASSERT_EQ((u32)moved, (u32)file);
+
+    fs.remove(moved);
+}
+
+TEST(mv_moves_file_to_directory) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* file = fs.createFile("mv_file.txt", cwd);
+    FileNode* dir = fs.createDirectory("mv_dest_dir", cwd);
+
+    const u8 data[] = {'a', 'b', 'c'};
+    fs.write(file, data, 3);
+
+    Command* cmd = Command::find("mv");
+    const char* args[] = {"mv", "mv_file.txt", "mv_dest_dir/mv_file.txt"};
+    cmd->execute(args, 3, cwd);
+
+    ASSERT(fs.resolve("mv_file.txt", cwd) == nullptr);
+    FileNode* moved = fs.resolve("mv_dest_dir/mv_file.txt", cwd);
+    ASSERT(moved != nullptr);
+    ASSERT_EQ(moved->size, 3);
+
+    fs.remove(moved);
+    fs.remove(dir);
+}
+
+TEST(mv_renames_directory) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    fs.createDirectory("mv_old_dir", cwd);
+
+    Command* cmd = Command::find("mv");
+    const char* args[] = {"mv", "mv_old_dir", "mv_new_dir"};
+    cmd->execute(args, 3, cwd);
+
+    ASSERT(fs.resolve("mv_old_dir", cwd) == nullptr);
+    FileNode* moved = fs.resolve("mv_new_dir", cwd);
+    ASSERT(moved != nullptr);
+    ASSERT(moved->type == FileNodeType::Directory);
+
+    fs.remove(moved);
+}
+
+TEST(mv_missing_args) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+
+    Command* cmd = Command::find("mv");
+    const char* args1[] = {"mv"};
+    ASSERT(cmd->execute(args1, 1, cwd));
+
+    const char* args2[] = {"mv", "something"};
+    ASSERT(cmd->execute(args2, 2, cwd));
+}
+
+TEST(mv_nonexistent_source) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+
+    Command* cmd = Command::find("mv");
+    const char* args[] = {"mv", "no_such.txt", "dest.txt"};
+    ASSERT(cmd->execute(args, 3, cwd));
+}
+
+// --- cp ---
+
+TEST(cp_copies_file) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* file = fs.createFile("cp_src.txt", cwd);
+    const u8 data[] = {'x', 'y', 'z'};
+    fs.write(file, data, 3);
+
+    Command* cmd = Command::find("cp");
+    ASSERT(cmd != nullptr);
+
+    const char* args[] = {"cp", "cp_src.txt", "cp_dst.txt"};
+    cmd->execute(args, 3, cwd);
+
+    // Source still exists.
+    FileNode* src = fs.resolve("cp_src.txt", cwd);
+    ASSERT(src != nullptr);
+    ASSERT_EQ(src->size, 3);
+
+    // Destination is a separate copy.
+    FileNode* dst = fs.resolve("cp_dst.txt", cwd);
+    ASSERT(dst != nullptr);
+    ASSERT_EQ(dst->size, 3);
+    ASSERT_EQ((u32)dst->data[0], (u32)'x');
+    ASSERT((u32)dst != (u32)src);
+
+    fs.remove(src);
+    fs.remove(dst);
+}
+
+TEST(cp_copies_empty_file) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* file = fs.createFile("cp_empty.txt", cwd);
+
+    Command* cmd = Command::find("cp");
+    const char* args[] = {"cp", "cp_empty.txt", "cp_empty_dst.txt"};
+    cmd->execute(args, 3, cwd);
+
+    FileNode* dst = fs.resolve("cp_empty_dst.txt", cwd);
+    ASSERT(dst != nullptr);
+    ASSERT_EQ(dst->size, 0);
+
+    fs.remove(file);
+    fs.remove(dst);
+}
+
+TEST(cp_directory_fails) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+    FileNode* dir = fs.createDirectory("cp_dir", cwd);
+
+    Command* cmd = Command::find("cp");
+    const char* args[] = {"cp", "cp_dir", "cp_dir_copy"};
+    ASSERT(cmd->execute(args, 3, cwd));
+
+    // No copy should exist.
+    ASSERT(fs.resolve("cp_dir_copy", cwd) == nullptr);
+
+    fs.remove(dir);
+}
+
+TEST(cp_missing_args) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+
+    Command* cmd = Command::find("cp");
+    const char* args1[] = {"cp"};
+    ASSERT(cmd->execute(args1, 1, cwd));
+
+    const char* args2[] = {"cp", "something"};
+    ASSERT(cmd->execute(args2, 2, cwd));
+}
+
+TEST(cp_nonexistent_source) {
+    Filesystem& fs = Filesystem::getFilesystem();
+    FileNode* cwd = fs.getRoot();
+
+    Command* cmd = Command::find("cp");
+    const char* args[] = {"cp", "no_such.txt", "dest.txt"};
+    ASSERT(cmd->execute(args, 3, cwd));
+}


### PR DESCRIPTION
## Summary
- `mv <source> <destination>` -- move or rename a file or directory
- `cp <source> <destination>` -- deep copy a file (directories not supported, per `fs.copy()`)
- 10 new tests covering both commands

Closes #53

## Test plan
- [x] `make test` passes (145/145, including 10 new tests)
- [x] Manual test: `touch a.txt && mv a.txt b.txt && ls` shows b.txt
- [x] Manual test: `touch c.txt && write c.txt hello && cp c.txt d.txt && cat d.txt` shows "hello"
- [x] Manual test: error cases (mv nonexistent, cp directory, missing args)