### PR TITLE
#61: Add line-scrolling to VGA terminal

### DIFF
--- a/include/hardware/terminal.hpp
+++ b/include/hardware/terminal.hpp
@@ -82,6 +82,7 @@ private:
     VgaTerminal();
 
     void updateCursor();
+    void scrollUp();
 
 public:
     ~VgaTerminal() = default;

--- a/src/hardware/terminal.cpp
+++ b/src/hardware/terminal.cpp
@@ -95,7 +95,7 @@ void VgaTerminal::putchar(char ch) {
     }
 
     if (y >= VGA_HEIGHT) {
-        clear();
+        scrollUp();
     }
 
     updateCursor();
@@ -139,6 +139,20 @@ void VgaTerminal::print_dec(u32 value) {
     while (--i >= 0) {
         putchar(buf[i]);
     }
+}
+
+void VgaTerminal::scrollUp() {
+    for (u8 row = 1; row < VGA_HEIGHT; ++row) {
+        for (u8 col = 0; col < VGA_WIDTH; ++col) {
+            buffer[VGA_WIDTH * (row - 1) + col] = buffer[VGA_WIDTH * row + col];
+        }
+    }
+
+    for (u8 col = 0; col < VGA_WIDTH; ++col) {
+        buffer[VGA_WIDTH * (VGA_HEIGHT - 1) + col] = color | ' ';
+    }
+
+    y = VGA_HEIGHT - 1;
 }
 
 void VgaTerminal::clear() {

--- a/tests/test_terminal.cpp
+++ b/tests/test_terminal.cpp
@@ -90,6 +90,29 @@ TEST(terminal_get_cursor) {
     ASSERT_EQ(static_cast<u32>(vga.getCursorY()), 0u);
 }
 
+TEST(terminal_scroll) {
+    VgaTerminal& vga = VgaTerminal::getTerminal();
+    vga.clear();
+
+    u16* buf = reinterpret_cast<u16*>(0xB8000);
+
+    // Place 'Z' on row 1, then trigger a scroll from the last row.
+    vga.setCursor(0, 1);
+    vga.putchar('Z');
+    vga.setCursor(0, VGA_HEIGHT - 1);
+    vga.putchar('\n');
+
+    // 'Z' should have moved from row 1 to row 0.
+    ASSERT_EQ(static_cast<u32>(buf[0] & 0x00FF), static_cast<u32>('Z'));
+
+    // Last row should be blank.
+    ASSERT_EQ(static_cast<u32>(buf[VGA_WIDTH * (VGA_HEIGHT - 1)] & 0x00FF), static_cast<u32>(' '));
+
+    // Cursor should be at column 0 of the last row.
+    ASSERT_EQ(static_cast<u32>(vga.getCursorY()), static_cast<u32>(VGA_HEIGHT - 1));
+    ASSERT_EQ(static_cast<u32>(vga.getCursorX()), 0u);
+}
+
 TEST(terminal_set_cursor) {
     VgaTerminal& vga = VgaTerminal::getTerminal();
     vga.clear();


### PR DESCRIPTION
## Summary
- Replace auto-clear with upward scrolling when the cursor moves past the last row
- Shift all lines up by one and continue writing on the bottom row
- Add test verifying scroll moves content up and blanks the last row

Closes #61