### PR TITLE
#66: Standardize command error messages to show usage

### DIFF
--- a/src/core/commands/file/content.cpp
+++ b/src/core/commands/file/content.cpp
@@ -28,7 +28,7 @@ bool CatCommand::execute(const char** args, usize argc,
     VgaTerminal& vga = VgaTerminal::getTerminal();
 
     if (argc < 2) {
-        vga.print("cat: missing operand\n");
+        vga.print("cat: usage: cat <filename>\n");
         return true;
     }
 

--- a/src/core/commands/file/management.cpp
+++ b/src/core/commands/file/management.cpp
@@ -27,7 +27,7 @@ bool MkdirCommand::execute(const char** args, usize argc,
     VgaTerminal& vga = VgaTerminal::getTerminal();
 
     if (argc < 2) {
-        vga.print("mkdir: missing operand\n");
+        vga.print("mkdir: usage: mkdir <path>\n");
         return true;
     }
 
@@ -53,7 +53,7 @@ bool RmdirCommand::execute(const char** args, usize argc,
     VgaTerminal& vga = VgaTerminal::getTerminal();
 
     if (argc < 2) {
-        vga.print("rmdir: missing operand\n");
+        vga.print("rmdir: usage: rmdir <path>\n");
         return true;
     }
 
@@ -93,7 +93,7 @@ bool TouchCommand::execute(const char** args, usize argc,
     VgaTerminal& vga = VgaTerminal::getTerminal();
 
     if (argc < 2) {
-        vga.print("touch: missing operand\n");
+        vga.print("touch: usage: touch <path>\n");
         return true;
     }
 
@@ -119,7 +119,7 @@ bool RmCommand::execute(const char** args, usize argc,
     VgaTerminal& vga = VgaTerminal::getTerminal();
 
     if (argc < 2) {
-        vga.print("rm: missing operand\n");
+        vga.print("rm: usage: rm <path>\n");
         return true;
     }
 


### PR DESCRIPTION
## Summary
- Replace "missing operand" messages in mkdir, rmdir, touch, rm, and cat with usage hints
- Matches the format already used by mv, cp, and write (e.g., "rm: usage: rm <path>")

Closes #66