### PR TITLE
#85: Add per-process address spaces

### DIFF
--- a/include/memory/paging.hpp
+++ b/include/memory/paging.hpp
@@ -32,6 +32,30 @@ public:
     void unmapPage(u32 virtualAddr);
     void flushTLB(u32 virtualAddr);
 
+    /**
+     * @brief Creates a new address space with shared kernel mappings.
+     *
+     * Allocates a page directory frame, copies kernel PDEs (768-1023)
+     * from the kernel page directory, and zeroes user PDEs (0-767).
+     * Returns the physical address of the new page directory, or 0 on failure.
+     *
+     */
+    u32 createAddressSpace();
+
+    /**
+     * @brief Maps a page in an arbitrary page directory.
+     *
+     * Accesses the target page directory and page tables via phys + KERNEL_VBASE.
+     *
+     */
+    void mapUserPage(u32 pdPhysical, u32 virtualAddr, u32 physicalAddr, u16 flags);
+
+    /**
+     * @brief Frees all user page tables, mapped user frames, and the page directory.
+     *
+     */
+    void destroyAddressSpace(u32 pdPhysical);
+
     PagingManager(const PagingManager&) = delete;
     PagingManager(PagingManager&&) = delete;
     PagingManager& operator=(const PagingManager&) = delete;

--- a/src/memory/paging.cpp
+++ b/src/memory/paging.cpp
@@ -115,3 +115,78 @@ void PagingManager::unmapPage(u32 virtualAddr) {
 void PagingManager::flushTLB(u32 virtualAddr) {
     asm volatile("invlpg (%0)" :: "r"(virtualAddr) : "memory");
 }
+
+u32 PagingManager::createAddressSpace() {
+    PhysicalMemoryManager& pmm = PhysicalMemoryManager::getManager();
+    void* frame = pmm.allocFrame();
+    if (!frame) {
+        return 0;
+    }
+
+    u32* newPd = (u32*)((u32)frame + KERNEL_VBASE);
+
+    // Zero user PDEs (0-767).
+    for (u32 i = 0; i < 768; i++) {
+        newPd[i] = 0;
+    }
+
+    // Copy kernel PDEs (768-1023) so kernel mappings are shared.
+    for (u32 i = 768; i < 1024; i++) {
+        newPd[i] = pageDirectory[i];
+    }
+
+    return (u32)frame;
+}
+
+void PagingManager::mapUserPage(u32 pdPhysical, u32 virtualAddr, u32 physicalAddr, u16 flags) {
+    u32* pd = (u32*)(pdPhysical + KERNEL_VBASE);
+    u32 pdIndex = virtualAddr >> 22;
+    u32 ptIndex = (virtualAddr >> 12) & 0x3FF;
+
+    // Allocate a page table if this directory entry is empty.
+    if (!(pd[pdIndex] & PAGE_PRESENT)) {
+        PhysicalMemoryManager& pmm = PhysicalMemoryManager::getManager();
+        void* ptFrame = pmm.allocFrame();
+        if (!ptFrame) {
+            return;
+        }
+
+        u32* pageTable = (u32*)((u32)ptFrame + KERNEL_VBASE);
+        for (u32 i = 0; i < 1024; i++) {
+            pageTable[i] = 0;
+        }
+
+        pd[pdIndex] = (u32)ptFrame | PAGE_PRESENT | PAGE_READWRITE | PAGE_USER;
+    }
+
+    u32* pageTable = (u32*)((pd[pdIndex] & 0xFFFFF000) + KERNEL_VBASE);
+    pageTable[ptIndex] = (physicalAddr & 0xFFFFF000) | (flags & 0xFFF);
+}
+
+void PagingManager::destroyAddressSpace(u32 pdPhysical) {
+    PhysicalMemoryManager& pmm = PhysicalMemoryManager::getManager();
+    u32* pd = (u32*)(pdPhysical + KERNEL_VBASE);
+
+    // Walk user PDEs only (0-767). Kernel PDEs (768-1023) are shared.
+    for (u32 i = 0; i < 768; i++) {
+        if (!(pd[i] & PAGE_PRESENT)) {
+            continue;
+        }
+
+        u32 ptPhysical = pd[i] & 0xFFFFF000;
+        u32* pageTable = (u32*)(ptPhysical + KERNEL_VBASE);
+
+        // Free all mapped user frames in this page table.
+        for (u32 j = 0; j < 1024; j++) {
+            if (pageTable[j] & PAGE_PRESENT) {
+                pmm.freeFrame((void*)(pageTable[j] & 0xFFFFF000));
+            }
+        }
+
+        // Free the page table frame itself.
+        pmm.freeFrame((void*)ptPhysical);
+    }
+
+    // Free the page directory frame.
+    pmm.freeFrame((void*)pdPhysical);
+}

--- a/tests/memory/test_paging.cpp
+++ b/tests/memory/test_paging.cpp
@@ -103,3 +103,62 @@ TEST(paging_pmm_returns_physical_addresses) {
     ASSERT((u32)frame < KERNEL_VBASE);
     pmm.freeFrame(frame);
 }
+
+TEST(paging_create_address_space_returns_physical) {
+    PagingManager& pm = PagingManager::getManager();
+    u32 pd = pm.createAddressSpace();
+    ASSERT(pd != 0);
+    ASSERT(pd < KERNEL_VBASE);
+
+    pm.destroyAddressSpace(pd);
+}
+
+TEST(paging_create_address_space_shares_kernel_pdes) {
+    PagingManager& pm = PagingManager::getManager();
+    u32 pd = pm.createAddressSpace();
+    ASSERT(pd != 0);
+
+    // Read current kernel CR3 to get the kernel page directory physical address.
+    u32 cr3;
+    asm volatile("mov %%cr3, %0" : "=r"(cr3));
+    u32* kernelPd = (u32*)(cr3 + KERNEL_VBASE);
+    u32* newPd = (u32*)(pd + KERNEL_VBASE);
+
+    // Kernel PDEs (768-1023) must be identical.
+    for (u32 i = 768; i < 1024; i++) {
+        ASSERT_EQ(newPd[i], kernelPd[i]);
+    }
+
+    // User PDEs (0-767) must be zeroed.
+    for (u32 i = 0; i < 768; i++) {
+        ASSERT_EQ(newPd[i], 0u);
+    }
+
+    pm.destroyAddressSpace(pd);
+}
+
+TEST(paging_map_user_page_creates_mapping) {
+    PagingManager& pm = PagingManager::getManager();
+    PhysicalMemoryManager& pmm = PhysicalMemoryManager::getManager();
+
+    u32 pd = pm.createAddressSpace();
+    ASSERT(pd != 0);
+
+    void* frame = pmm.allocFrame();
+    ASSERT(frame != nullptr);
+
+    u32 userVirt = 0x00400000;
+    pm.mapUserPage(pd, userVirt, (u32)frame, PAGE_PRESENT | PAGE_READWRITE | PAGE_USER);
+
+    // Verify the PTE was created by reading the page table.
+    u32* pdPtr = (u32*)(pd + KERNEL_VBASE);
+    u32 pdIndex = userVirt >> 22;
+    ASSERT(pdPtr[pdIndex] & PAGE_PRESENT);
+
+    u32* pt = (u32*)((pdPtr[pdIndex] & 0xFFFFF000) + KERNEL_VBASE);
+    u32 ptIndex = (userVirt >> 12) & 0x3FF;
+    ASSERT(pt[ptIndex] & PAGE_PRESENT);
+    ASSERT_EQ(pt[ptIndex] & 0xFFFFF000, (u32)frame);
+
+    pm.destroyAddressSpace(pd);
+}


### PR DESCRIPTION
## Summary
- `PagingManager::createAddressSpace()` -- allocates page directory, copies kernel PDEs (768-1023), zeroes user PDEs (0-767)
- `PagingManager::mapUserPage(pdPhysical, virtualAddr, physicalAddr, flags)` -- maps a page in an arbitrary page directory via phys + KERNEL_VBASE
- `PagingManager::destroyAddressSpace(pdPhysical)` -- frees user page tables, mapped frames, and the page directory frame

## Test plan
- [x] `make test` -- 187 tests pass (3 new)
  - createAddressSpace returns non-zero physical address below KERNEL_VBASE
  - Kernel PDEs (768-1023) shared with kernel page directory; user PDEs (0-767) zeroed
  - mapUserPage creates PDE and PTE with correct physical address and flags

Closes #85