### PR TITLE
#86: Add ELF32 loader with multiboot module support

### DIFF
--- a/include/core/elf.hpp
+++ b/include/core/elf.hpp
@@ -1,0 +1,85 @@
+/**
+ * elf.hpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#ifndef CORE_ELF_HPP_
+#define CORE_ELF_HPP_
+
+#include <common/types.hpp>
+
+namespace cassio {
+namespace kernel {
+
+struct __attribute__((packed)) Elf32Header {
+    u8  e_ident[16];
+    u16 e_type;
+    u16 e_machine;
+    u32 e_version;
+    u32 e_entry;
+    u32 e_phoff;
+    u32 e_shoff;
+    u32 e_flags;
+    u16 e_ehsize;
+    u16 e_phentsize;
+    u16 e_phnum;
+    u16 e_shentsize;
+    u16 e_shnum;
+    u16 e_shstrndx;
+};
+
+struct __attribute__((packed)) Elf32ProgramHeader {
+    u32 p_type;
+    u32 p_offset;
+    u32 p_vaddr;
+    u32 p_paddr;
+    u32 p_filesz;
+    u32 p_memsz;
+    u32 p_flags;
+    u32 p_align;
+};
+
+// ELF identification indices.
+static constexpr u32 EI_MAG0    = 0;
+static constexpr u32 EI_CLASS   = 4;
+
+// ELF magic bytes.
+static constexpr u8 ELFMAG0 = 0x7F;
+static constexpr u8 ELFMAG1 = 'E';
+static constexpr u8 ELFMAG2 = 'L';
+static constexpr u8 ELFMAG3 = 'F';
+
+// ELF class.
+static constexpr u8 ELFCLASS32 = 1;
+
+// ELF type.
+static constexpr u16 ET_EXEC = 2;
+
+// ELF machine.
+static constexpr u16 EM_386 = 3;
+
+// Program header types.
+static constexpr u32 PT_LOAD = 1;
+
+struct ElfLoadResult {
+    u32 entryPoint;
+    bool success;
+};
+
+/**
+ * @brief Loads ELF32 executables into a given address space.
+ *
+ */
+class ElfLoader {
+public:
+    static ElfLoadResult load(u32 pdPhysical, const u8* elfData, u32 elfSize);
+};
+
+} // kernel
+} // cassio
+
+#endif // CORE_ELF_HPP_

--- a/include/memory/multiboot.hpp
+++ b/include/memory/multiboot.hpp
@@ -35,6 +35,14 @@ struct __attribute__((packed)) MultibootMmapEntry {
     u32 type;
 };
 
+struct __attribute__((packed)) MultibootModule {
+    u32 mod_start;
+    u32 mod_end;
+    u32 string;
+    u32 reserved;
+};
+
+static constexpr u32 MULTIBOOT_FLAG_MODS = (1 << 3);
 static constexpr u32 MULTIBOOT_FLAG_MMAP = (1 << 6);
 static constexpr u32 MULTIBOOT_MMAP_AVAILABLE = 1;
 

--- a/src/core/elf.cpp
+++ b/src/core/elf.cpp
@@ -1,0 +1,96 @@
+/**
+ * elf.cpp
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+#include "core/elf.hpp"
+#include "memory/paging.hpp"
+#include "memory/physical.hpp"
+#include "memory/virtual.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::memory;
+
+ElfLoadResult ElfLoader::load(u32 pdPhysical, const u8* elfData, u32 elfSize) {
+    ElfLoadResult result = {0, false};
+
+    if (elfSize < sizeof(Elf32Header)) {
+        return result;
+    }
+
+    const Elf32Header* header = (const Elf32Header*)elfData;
+
+    // Validate magic.
+    if (header->e_ident[EI_MAG0] != ELFMAG0 ||
+        header->e_ident[1] != ELFMAG1 ||
+        header->e_ident[2] != ELFMAG2 ||
+        header->e_ident[3] != ELFMAG3) {
+        return result;
+    }
+
+    // Validate class (32-bit), type (executable), machine (i386).
+    if (header->e_ident[EI_CLASS] != ELFCLASS32) {
+        return result;
+    }
+    if (header->e_type != ET_EXEC) {
+        return result;
+    }
+    if (header->e_machine != EM_386) {
+        return result;
+    }
+
+    PagingManager& paging = PagingManager::getManager();
+    PhysicalMemoryManager& pmm = PhysicalMemoryManager::getManager();
+
+    u32 phoff = header->e_phoff;
+    u16 phnum = header->e_phnum;
+    u16 phentsize = header->e_phentsize;
+
+    for (u16 i = 0; i < phnum; i++) {
+        u32 offset = phoff + i * phentsize;
+        if (offset + sizeof(Elf32ProgramHeader) > elfSize) {
+            return result;
+        }
+
+        const Elf32ProgramHeader* ph = (const Elf32ProgramHeader*)(elfData + offset);
+
+        if (ph->p_type != PT_LOAD) {
+            continue;
+        }
+
+        // Allocate physical frames and map into the target address space.
+        u32 numPages = (ph->p_memsz + FRAME_SIZE - 1) / FRAME_SIZE;
+        for (u32 p = 0; p < numPages; p++) {
+            void* frame = pmm.allocFrame();
+            if (!frame) {
+                return result;
+            }
+
+            u32 vaddr = (ph->p_vaddr & 0xFFFFF000) + p * FRAME_SIZE;
+            paging.mapUserPage(pdPhysical, vaddr, (u32)frame,
+                               PAGE_PRESENT | PAGE_READWRITE | PAGE_USER);
+
+            // Access the frame via the kernel direct map to copy/zero data.
+            u8* dest = (u8*)((u32)frame + KERNEL_VBASE);
+
+            u32 pageStart = p * FRAME_SIZE;
+            for (u32 b = 0; b < FRAME_SIZE; b++) {
+                u32 segOffset = pageStart + b;
+                if (segOffset < ph->p_filesz && ph->p_offset + segOffset < elfSize) {
+                    dest[b] = elfData[ph->p_offset + segOffset];
+                } else {
+                    dest[b] = 0;
+                }
+            }
+        }
+    }
+
+    result.entryPoint = header->e_entry;
+    result.success = true;
+    return result;
+}

--- a/tests/core/test_elf.cpp
+++ b/tests/core/test_elf.cpp
@@ -1,0 +1,105 @@
+#include <core/elf.hpp>
+#include <memory/paging.hpp>
+#include <memory/physical.hpp>
+#include "test.hpp"
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::memory;
+
+// Build a minimal valid ELF32 executable with one PT_LOAD segment.
+// The segment loads 4 bytes of code at virtual address 0x00400000.
+static void buildMinimalElf(u8* buf, u32& size) {
+    // Zero the buffer.
+    for (u32 i = 0; i < 256; i++) buf[i] = 0;
+
+    // ELF header (52 bytes).
+    Elf32Header* h = (Elf32Header*)buf;
+    h->e_ident[0] = 0x7F;
+    h->e_ident[1] = 'E';
+    h->e_ident[2] = 'L';
+    h->e_ident[3] = 'F';
+    h->e_ident[4] = 1;         // ELFCLASS32
+    h->e_ident[5] = 1;         // little-endian
+    h->e_ident[6] = 1;         // ELF version
+    h->e_type = 2;             // ET_EXEC
+    h->e_machine = 3;          // EM_386
+    h->e_version = 1;
+    h->e_entry = 0x00400000;
+    h->e_phoff = sizeof(Elf32Header);
+    h->e_phentsize = sizeof(Elf32ProgramHeader);
+    h->e_phnum = 1;
+    h->e_ehsize = sizeof(Elf32Header);
+
+    // Program header (32 bytes), immediately after ELF header.
+    Elf32ProgramHeader* ph = (Elf32ProgramHeader*)(buf + sizeof(Elf32Header));
+    ph->p_type = 1;            // PT_LOAD
+    ph->p_offset = 128;        // data starts at byte 128 in the file
+    ph->p_vaddr = 0x00400000;
+    ph->p_paddr = 0x00400000;
+    ph->p_filesz = 4;
+    ph->p_memsz = 4;
+    ph->p_flags = 5;           // PF_R | PF_X
+    ph->p_align = 0x1000;
+
+    // 4 bytes of "code" at offset 128.
+    buf[128] = 0xDE;
+    buf[129] = 0xAD;
+    buf[130] = 0xBE;
+    buf[131] = 0xEF;
+
+    size = 132;
+}
+
+TEST(elf_load_valid_returns_entry_point) {
+    u8 buf[256];
+    u32 size;
+    buildMinimalElf(buf, size);
+
+    PagingManager& pm = PagingManager::getManager();
+    u32 pd = pm.createAddressSpace();
+    ASSERT(pd != 0);
+
+    ElfLoadResult result = ElfLoader::load(pd, buf, size);
+    ASSERT(result.success);
+    ASSERT_EQ(result.entryPoint, 0x00400000u);
+
+    pm.destroyAddressSpace(pd);
+}
+
+TEST(elf_load_invalid_magic_fails) {
+    u8 buf[256];
+    u32 size;
+    buildMinimalElf(buf, size);
+
+    // Corrupt magic byte.
+    buf[0] = 0x00;
+
+    PagingManager& pm = PagingManager::getManager();
+    u32 pd = pm.createAddressSpace();
+    ASSERT(pd != 0);
+
+    ElfLoadResult result = ElfLoader::load(pd, buf, size);
+    ASSERT(!result.success);
+
+    pm.destroyAddressSpace(pd);
+}
+
+TEST(elf_load_wrong_machine_fails) {
+    u8 buf[256];
+    u32 size;
+    buildMinimalElf(buf, size);
+
+    // Change machine to ARM (0x28) instead of i386 (0x03).
+    Elf32Header* h = (Elf32Header*)buf;
+    h->e_machine = 0x28;
+
+    PagingManager& pm = PagingManager::getManager();
+    u32 pd = pm.createAddressSpace();
+    ASSERT(pd != 0);
+
+    ElfLoadResult result = ElfLoader::load(pd, buf, size);
+    ASSERT(!result.success);
+
+    pm.destroyAddressSpace(pd);
+}


### PR DESCRIPTION
## Summary
- `MultibootModule` struct added to `multiboot.hpp` for accessing GRUB module start/end addresses
- `Elf32Header` and `Elf32ProgramHeader` structs in `core/elf.hpp`
- `ElfLoader::load(pdPhysical, elfData, elfSize)` -- validates ELF32 headers, maps PT_LOAD segments into target address space, returns entry point

## Test plan
- [x] `make test` -- 190 tests pass (3 new)
  - Minimal valid ELF32 in byte array: load() succeeds, returns correct entry point (0x00400000)
  - Invalid magic: success = false
  - Wrong machine type (ARM instead of i386): success = false

Closes #86