### PR TITLE
#87: Build init userspace program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,11 @@ LDFLAGS = -melf_i386
 
 KERNEL = bin/cassio.bin
 TEST_KERNEL = bin/cassio-test.bin
+INIT = bin/init.elf
 ISO = bin/cassio.iso
 DISK = bin/disk.img
+
+INIT_CXXFLAGS = -m32 -ffreestanding -nostdlib -fno-exceptions -fno-rtti -fno-leading-underscore -fno-stack-protector
 
 # Discover all source files automatically.
 cpp_sources = $(shell find src/ -name '*.cpp')
@@ -36,6 +39,11 @@ obj/%.o: src/%.s
 kernel: src/linker.ld $(objects)
 	@mkdir -p bin
 	ld $(LDFLAGS) -T $< -o $(KERNEL) $(objects)
+
+$(INIT): userspace/init/main.cpp userspace/init/linker.ld
+	@mkdir -p bin obj/userspace/init
+	g++ $(INIT_CXXFLAGS) -o obj/userspace/init/main.o -c userspace/init/main.cpp
+	ld $(LDFLAGS) -T userspace/init/linker.ld -o $(INIT) obj/userspace/init/main.o
 
 # Compile test files from the tests/ directory.
 obj/tests/%.o: tests/%.cpp
@@ -78,10 +86,11 @@ iso: kernel
 	grub-mkrescue --output=$(ISO) iso
 	rm -rf iso
 
-run: kernel $(DISK)
+run: kernel $(INIT) $(DISK)
 	qemu-system-i386 -machine pc -kernel $(KERNEL) \
+	    -initrd $(INIT) \
 	    -drive file=$(DISK),format=raw,if=ide
 
-.PHONY: kernel iso clean run test
+.PHONY: kernel iso clean run test init
 clean:
 	rm -rf obj/ bin/

--- a/userspace/init/linker.ld
+++ b/userspace/init/linker.ld
@@ -1,0 +1,36 @@
+/**
+ * linker.ld -- init userspace linker script
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ */
+
+ENTRY(_start)
+OUTPUT_FORMAT(elf32-i386)
+OUTPUT_ARCH(i386:i386)
+
+SECTIONS {
+    . = 0x00400000;
+
+    .text : {
+        *(.text*)
+        *(.rodata*)
+    }
+
+    .data : {
+        *(.data)
+    }
+
+    .bss : {
+        *(.bss)
+    }
+
+    /DISCARD/ : {
+        *(.fini_array*)
+        *(.init_array*)
+        *(.comment)
+        *(.eh_frame*)
+    }
+}

--- a/userspace/init/main.cpp
+++ b/userspace/init/main.cpp
@@ -1,0 +1,76 @@
+/**
+ * main.cpp -- init userspace program
+ *
+ * Copyright (c) 2019-2026 Giovanni Giacomo. All Rights Reserved.
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file.
+ *
+ * First userspace process. Prints uptime every 5 seconds via syscalls.
+ *
+ */
+
+using u32 = unsigned int;
+using i32 = int;
+
+static inline i32 syscall(u32 number, u32 arg1 = 0, u32 arg2 = 0, u32 arg3 = 0) {
+    i32 ret;
+    asm volatile(
+        "int $0x80"
+        : "=a"(ret)
+        : "a"(number), "b"(arg1), "c"(arg2), "d"(arg3)
+        : "memory"
+    );
+    return ret;
+}
+
+static i32 sys_write(u32 fd, const char* buf, u32 len) {
+    return syscall(0, fd, (u32)buf, len);
+}
+
+static i32 sys_sleep(u32 ms) {
+    return syscall(2, ms);
+}
+
+static i32 sys_uptime() {
+    return syscall(3);
+}
+
+static u32 strlen(const char* s) {
+    u32 len = 0;
+    while (s[len]) len++;
+    return len;
+}
+
+static void print(const char* s) {
+    sys_write(1, s, strlen(s));
+}
+
+static void print_dec(u32 value) {
+    if (value == 0) {
+        sys_write(1, "0", 1);
+        return;
+    }
+    char buf[12];
+    i32 i = 0;
+    while (value > 0) {
+        buf[i++] = '0' + (value % 10);
+        value /= 10;
+    }
+    // Reverse.
+    for (i32 j = 0; j < i / 2; j++) {
+        char tmp = buf[j];
+        buf[j] = buf[i - 1 - j];
+        buf[i - 1 - j] = tmp;
+    }
+    sys_write(1, buf, i);
+}
+
+extern "C" void _start() {
+    while (true) {
+        u32 ticks = (u32)sys_uptime();
+        print("init: alive, uptime = ");
+        print_dec(ticks);
+        print(" ticks\n");
+        sys_sleep(5000);
+    }
+}


### PR DESCRIPTION
## Summary
- `userspace/init/main.cpp` -- first userspace binary with inline `int $0x80` syscall wrappers
- `_start` loops: prints "init: alive, uptime = <ticks> ticks", sleeps 5 seconds, repeats
- `userspace/init/linker.ld` -- entry `_start`, `.text` at `0x00400000`
- New Makefile target `bin/init.elf`; `make run` passes `-initrd bin/init.elf` to QEMU

## Test plan
- [x] `make test` -- 190 tests pass (no regressions)
- [x] `bin/init.elf` is a valid ELF32 i386 executable (readelf confirms: Class=ELF32, Machine=Intel 80386, Type=EXEC, entry=0x4001ce)

Closes #87