### PR TITLE
#100: Add IRQ forwarding to userspace

### DIFF
--- a/kernel/include/hardware/irq.hpp
+++ b/kernel/include/hardware/irq.hpp
@@ -11,6 +11,7 @@
 #define HARDWARE_IRQ_HPP_
 
 #include <types.hpp>
+#include <message.hpp>
 #include <hardware/port.hpp>
 
 namespace cassio {
@@ -31,6 +32,8 @@ class Driver; // forward declaration
 class IrqManager final {
 private:
     Driver* drv[16];
+    u32 forwardPid[16];
+    bool pendingIrq[16];
 
     Port<u8> pic_master_cmd;
     Port<u8> pic_master_data;
@@ -84,6 +87,24 @@ public:
      *
      */
     void unregisterDriver(u8 vector, Driver* driver);
+
+    /**
+     * @brief Registers a userspace process to receive IRQ notifications.
+     *
+     * One process per IRQ. Returns 0 on success, -1 if irq is out of range.
+     *
+     */
+    i32 registerForward(u8 irq, u32 pid);
+
+    /**
+     * @brief Delivers a pending IRQ notification to a process.
+     *
+     * Scans for pending IRQs registered to the given PID and fills msg
+     * with the first one found. Returns true if a notification was
+     * delivered, false if none pending.
+     *
+     */
+    bool deliverPending(u32 pid, Message* msg);
 
     /** Deleted Methods */
     IrqManager(const IrqManager&) = delete;

--- a/kernel/src/core/syscall.cpp
+++ b/kernel/src/core/syscall.cpp
@@ -12,6 +12,7 @@
 #include "core/scheduler.hpp"
 #include "drivers/pit.hpp"
 #include "hardware/interrupt.hpp"
+#include "hardware/irq.hpp"
 #include "hardware/port.hpp"
 #include "hardware/serial.hpp"
 #include "hardware/terminal.hpp"
@@ -91,7 +92,13 @@ i32 SyscallHandler::receive(Message* msg) {
         return static_cast<i32>(senderPid);
     }
 
-    // No pending senders -- block.
+    // Check for pending IRQ notifications before blocking.
+    IrqManager& irqMgr = IrqManager::getManager();
+    if (irqMgr.deliverPending(receiver->pid, msg)) {
+        return -2;  // IRQ notification delivered; handleSyscall sets eax=0.
+    }
+
+    // No pending senders or IRQs -- block.
     receiver->msgPtr = (u32)msg;
     receiver->state = ProcessState::ReceiveBlocked;
     return 0;  // Caller should block.
@@ -185,12 +192,24 @@ u32 SyscallHandler::handleSyscall(u32 esp) {
             Scheduler& sched = Scheduler::getScheduler();
             return sched.reschedule(esp);
         }
+        if (result == -2) {
+            // Pending IRQ notification delivered. Return 0 (kernel PID).
+            frame->eax = 0;
+            return esp;
+        }
         frame->eax = static_cast<u32>(result);
         return esp;
     }
     case SyscallNumber::Reply: {
         i32 result = reply(frame->ebx, (Message*)frame->ecx);
         frame->eax = static_cast<u32>(result);
+        return esp;
+    }
+    case SyscallNumber::IrqRegister: {
+        IrqManager& irqMgr = IrqManager::getManager();
+        ProcessManager& pm = ProcessManager::getManager();
+        frame->eax = static_cast<u32>(irqMgr.registerForward(
+            static_cast<u8>(frame->ebx), pm.current()->pid));
         return esp;
     }
     case SyscallNumber::Write:

--- a/kernel/src/hardware/irq.cpp
+++ b/kernel/src/hardware/irq.cpp
@@ -10,6 +10,8 @@
 #include "hardware/irq.hpp"
 #include "hardware/driver.hpp"
 #include "hardware/interrupt.hpp"
+#include "core/process.hpp"
+#include "core/syscall.hpp"
 
 using namespace cassio;
 using namespace cassio::hardware;
@@ -64,7 +66,55 @@ u32 IrqManager::handleIrq(u8 number, u32 esp) {
         pic_slave_cmd.writeSlow(0x20);
     }
 
+    // Forward to userspace if a process is registered for this IRQ.
+    if (irq < 16 && forwardPid[irq] != 0) {
+        kernel::Process* target =
+            kernel::ProcessManager::getManager().get(forwardPid[irq]);
+        if (target && target->state == kernel::ProcessState::ReceiveBlocked) {
+            // Deliver IrqNotify message directly to the waiting process.
+            Message* buf = (Message*)target->msgPtr;
+            buf->type = MessageType::IrqNotify;
+            buf->arg1 = irq;
+            buf->arg2 = 0;
+            buf->arg3 = 0;
+            buf->arg4 = 0;
+            buf->arg5 = 0;
+
+            // Set receive() return value to 0 (kernel notification).
+            kernel::SyscallFrame* frame = (kernel::SyscallFrame*)target->esp;
+            frame->eax = 0;
+
+            target->state = kernel::ProcessState::Ready;
+        } else if (target) {
+            pendingIrq[irq] = true;
+        }
+    }
+
     return esp;
+}
+
+i32 IrqManager::registerForward(u8 irq, u32 pid) {
+    if (irq >= 16) {
+        return -1;
+    }
+    forwardPid[irq] = pid;
+    return 0;
+}
+
+bool IrqManager::deliverPending(u32 pid, Message* msg) {
+    for (u8 irq = 0; irq < 16; irq++) {
+        if (forwardPid[irq] == pid && pendingIrq[irq]) {
+            pendingIrq[irq] = false;
+            msg->type = MessageType::IrqNotify;
+            msg->arg1 = irq;
+            msg->arg2 = 0;
+            msg->arg3 = 0;
+            msg->arg4 = 0;
+            msg->arg5 = 0;
+            return true;
+        }
+    }
+    return false;
 }
 
 void IrqManager::registerDriver(u8 vector, Driver* driver) {

--- a/kernel/tests/hardware/test_irq.cpp
+++ b/kernel/tests/hardware/test_irq.cpp
@@ -1,10 +1,13 @@
 #include <hardware/irq.hpp>
 #include <hardware/driver.hpp>
+#include <core/process.hpp>
+#include <core/syscall.hpp>
 #include <drivers/pit.hpp>
 #include <test.hpp>
 
 using namespace cassio;
 using namespace cassio::hardware;
+using namespace cassio::kernel;
 using namespace cassio::drivers;
 
 TEST(irq_dispatch_to_pit) {
@@ -100,4 +103,159 @@ TEST(irq_idt_entries_are_distinct) {
             ASSERT(addrs[i] != addrs[j]);
         }
     }
+}
+
+// -- IRQ forwarding tests --
+
+TEST(irq_forward_delivers_to_receive_blocked_process) {
+    IrqManager& irqMgr = IrqManager::getManager();
+    ProcessManager& pm = ProcessManager::getManager();
+
+    // Create a process and simulate it blocked in receive().
+    Process* target = pm.create(0x1000, 0x2000, 0x08, 0x10, 0);
+    ASSERT(target != nullptr);
+
+    Message recvBuf = {};
+    target->state = ProcessState::ReceiveBlocked;
+    target->msgPtr = (u32)&recvBuf;
+
+    SyscallFrame frame = {};
+    target->esp = (u32)&frame;
+
+    // Register target for IRQ 5 (unused, no in-kernel driver).
+    irqMgr.registerForward(5, target->pid);
+
+    // Simulate IRQ 5 firing.
+    irqMgr.handleIrq(0x25, 0);
+
+    // Target should be woken with IrqNotify message.
+    ASSERT(target->state == ProcessState::Ready);
+    ASSERT_EQ(recvBuf.type, MessageType::IrqNotify);
+    ASSERT_EQ(recvBuf.arg1, 5u);
+
+    // Return value should be 0 (kernel PID).
+    ASSERT_EQ(frame.eax, 0u);
+
+    // Clean up.
+    irqMgr.registerForward(5, 0);
+    pm.destroy(target->pid);
+}
+
+TEST(irq_forward_sets_pending_when_not_receive_blocked) {
+    IrqManager& irqMgr = IrqManager::getManager();
+    ProcessManager& pm = ProcessManager::getManager();
+    SyscallHandler& sh = SyscallHandler::getSyscallHandler();
+
+    Process* target = pm.create(0x1000, 0x2000, 0x08, 0x10, 0);
+    ASSERT(target != nullptr);
+    target->state = ProcessState::Ready;  // Not ReceiveBlocked.
+
+    irqMgr.registerForward(5, target->pid);
+
+    // Simulate IRQ 5 while target is busy.
+    irqMgr.handleIrq(0x25, 0);
+
+    // Target should still be Ready (not woken from anything).
+    ASSERT(target->state == ProcessState::Ready);
+
+    // Now simulate target calling receive(). Pending IRQ should be delivered.
+    pm.setCurrent(target);
+    Message recvBuf = {};
+    i32 result = sh.receive(&recvBuf);
+
+    // -2 means IRQ notification delivered.
+    ASSERT_EQ(result, static_cast<i32>(-2));
+    ASSERT_EQ(recvBuf.type, MessageType::IrqNotify);
+    ASSERT_EQ(recvBuf.arg1, 5u);
+
+    // A second receive() with no more pending IRQs should block.
+    result = sh.receive(&recvBuf);
+    ASSERT_EQ(result, 0);
+    ASSERT(target->state == ProcessState::ReceiveBlocked);
+
+    // Clean up.
+    irqMgr.registerForward(5, 0);
+    pm.destroy(target->pid);
+}
+
+TEST(irq_forward_coexists_with_in_kernel_driver) {
+    IrqManager& irqMgr = IrqManager::getManager();
+    ProcessManager& pm = ProcessManager::getManager();
+    PitTimer& pit = PitTimer::getTimer();
+
+    // Register a process for IRQ 0 (PIT timer) alongside the in-kernel driver.
+    Process* target = pm.create(0x1000, 0x2000, 0x08, 0x10, 0);
+    ASSERT(target != nullptr);
+
+    Message recvBuf = {};
+    target->state = ProcessState::ReceiveBlocked;
+    target->msgPtr = (u32)&recvBuf;
+
+    SyscallFrame frame = {};
+    target->esp = (u32)&frame;
+
+    irqMgr.registerForward(0, target->pid);
+
+    // Fire IRQ 0. PIT should still increment ticks AND target should get notified.
+    u32 before = pit.getTicks();
+    irqMgr.handleIrq(0x20, 0);
+    u32 after = pit.getTicks();
+
+    ASSERT_EQ(after, before + 1);
+    ASSERT(target->state == ProcessState::Ready);
+    ASSERT_EQ(recvBuf.type, MessageType::IrqNotify);
+    ASSERT_EQ(recvBuf.arg1, 0u);
+
+    // Clean up.
+    irqMgr.registerForward(0, 0);
+    pm.destroy(target->pid);
+}
+
+TEST(irq_register_forward_invalid_irq_fails) {
+    IrqManager& irqMgr = IrqManager::getManager();
+
+    i32 result = irqMgr.registerForward(16, 1);
+    ASSERT_EQ(result, static_cast<i32>(-1));
+
+    result = irqMgr.registerForward(255, 1);
+    ASSERT_EQ(result, static_cast<i32>(-1));
+}
+
+TEST(irq_forward_sender_queue_takes_priority_over_pending_irq) {
+    IrqManager& irqMgr = IrqManager::getManager();
+    ProcessManager& pm = ProcessManager::getManager();
+    SyscallHandler& sh = SyscallHandler::getSyscallHandler();
+
+    Process* receiver = pm.create(0x1000, 0x2000, 0x08, 0x10, 0);
+    Process* sender = pm.create(0x3000, 0x4000, 0x08, 0x10, 0);
+    ASSERT(receiver != nullptr);
+    ASSERT(sender != nullptr);
+
+    // Set up: sender in queue AND pending IRQ for receiver.
+    sender->state = ProcessState::SendBlocked;
+    sender->msg = { 42, 1, 2, 3, 4, 5 };
+    receiver->sendQueuePush(sender->pid);
+
+    irqMgr.registerForward(5, receiver->pid);
+    receiver->state = ProcessState::Ready;
+    irqMgr.handleIrq(0x25, 0);  // Sets pending (receiver not ReceiveBlocked).
+
+    // receive() should deliver from the send queue first.
+    pm.setCurrent(receiver);
+    Message recvBuf = {};
+    i32 result = sh.receive(&recvBuf);
+
+    ASSERT_EQ(result, static_cast<i32>(sender->pid));
+    ASSERT_EQ(recvBuf.type, 42u);
+
+    // Next receive() should deliver the pending IRQ.
+    result = sh.receive(&recvBuf);
+    ASSERT_EQ(result, static_cast<i32>(-2));
+    ASSERT_EQ(recvBuf.type, MessageType::IrqNotify);
+    ASSERT_EQ(recvBuf.arg1, 5u);
+
+    // Clean up.
+    irqMgr.registerForward(5, 0);
+    pm.destroy(receiver->pid);
+    pm.destroy(sender->pid);
 }


### PR DESCRIPTION
## Summary

- Implement `IrqManager::registerForward(irq, pid)` to let userspace drivers claim hardware IRQs
- Update `IrqManager::handleIrq()` to deliver `MSG_IRQ_NOTIFY` messages to ReceiveBlocked processes, or set a pending flag if the target is busy
- Add `IrqManager::deliverPending()` and update `receive()` syscall to check pending IRQs before blocking
- Wire up `SyscallNumber::IrqRegister` dispatch in `handleSyscall()`
- EOI sent before forwarding; in-kernel drivers and forwarding coexist on the same IRQ

## Test plan

- [x] IRQ delivered to ReceiveBlocked process (message + state + return value)
- [x] Pending flag set when target is busy, delivered on next `receive()`
- [x] In-kernel driver (PIT) coexists with forwarding on same IRQ
- [x] Invalid IRQ number rejected
- [x] Send queue takes priority over pending IRQ notifications
- [x] All 220 kernel tests + 4 userspace tests pass

Closes #100

Generated with [Claude Code](https://claude.com/claude-code)