### PR TITLE
#134: Add ps command to list running processes

### DIFF
--- a/common/include/message.hpp
+++ b/common/include/message.hpp
@@ -56,6 +56,9 @@ namespace MessageType {
     // ATA.
     constexpr u32 AtaRead      = 18;
     constexpr u32 AtaWrite     = 19;
+
+    // Nameserver (extended).
+    constexpr u32 NsListAll    = 20;
 }
 
 } // cassio

--- a/common/include/syscall.hpp
+++ b/common/include/syscall.hpp
@@ -29,8 +29,15 @@ namespace SyscallNumber {
     constexpr u32 Notify      = 11;
     constexpr u32 MemInfo     = 12;
     constexpr u32 Sbrk        = 13;
-    constexpr u32 Count       = 14;
+    constexpr u32 ProcList    = 14;
+    constexpr u32 Count       = 15;
 }
+
+struct ProcEntry {
+    u32 pid;
+    u32 state;
+    u32 heapSize;
+};
 
 } // cassio
 

--- a/kernel/include/core/process.hpp
+++ b/kernel/include/core/process.hpp
@@ -53,6 +53,7 @@ struct Process {
 
     u32 pageDirectory;
     u32 kernelEsp;
+    u32 heapBase;   // Initial heap address (set once at ELF load, for heap size).
     u32 heapBreak;  // Current top of process heap (page-aligned, for sbrk).
 
     // IPC state.

--- a/kernel/include/core/syscall.hpp
+++ b/kernel/include/core/syscall.hpp
@@ -116,6 +116,15 @@ public:
      */
     u32 sbrk(u32 increment);
 
+    /**
+     * @brief Returns process info for all userspace processes.
+     *
+     * Writes up to maxEntries ProcEntry structs into buf, skipping PID 0.
+     * Returns the number of entries written.
+     *
+     */
+    u32 procList(ProcEntry* buf, u32 maxEntries);
+
     /** Deleted Methods */
     SyscallHandler(const SyscallHandler&) = delete;
     SyscallHandler(SyscallHandler&&) = delete;

--- a/kernel/src/core/kernel.cpp
+++ b/kernel/src/core/kernel.cpp
@@ -124,6 +124,7 @@ void start(void* multiboot, u32 magic) {
                 elf.entryPoint, (u32)frame, userCS, userDS, pdPhysical);
             if (proc) {
                 proc->kernelEsp = kernelStackTop;
+                proc->heapBase = elf.heapStart;
                 proc->heapBreak = elf.heapStart;
             }
         }

--- a/kernel/src/core/process.cpp
+++ b/kernel/src/core/process.cpp
@@ -35,6 +35,7 @@ ProcessManager::ProcessManager()
     kernelTask.ds = 0;
     kernelTask.pageDirectory = 0;
     kernelTask.kernelEsp = 0;
+    kernelTask.heapBase = 0;
     kernelTask.heapBreak = 0;
     kernelTask.msg = {};
     kernelTask.msgPtr = 0;
@@ -137,6 +138,7 @@ Process* ProcessManager::create(u32 eip, u32 esp, u32 cs, u32 ds, u32 pageDirect
     p->eflags = 0x202;
     p->pageDirectory = pageDirectory;
     p->kernelEsp = 0;
+    p->heapBase = 0;
     p->heapBreak = 0;
     p->msg = {};
     p->msgPtr = 0;

--- a/kernel/src/core/syscall.cpp
+++ b/kernel/src/core/syscall.cpp
@@ -359,6 +359,24 @@ void SyscallHandler::exit(u32 code) {
     debug_exit.write(code == 0 ? 0x00 : 0x01);
 }
 
+u32 SyscallHandler::procList(ProcEntry* buf, u32 maxEntries) {
+    ProcessManager& pm = ProcessManager::getManager();
+    u32 count = 0;
+
+    for (Process* p = pm.getHead(); p && count < maxEntries; p = p->next) {
+        if (p->pid == 0) {
+            continue;  // Skip kernel task.
+        }
+        buf[count].pid = p->pid;
+        buf[count].state = static_cast<u32>(p->state);
+        buf[count].heapSize = (p->heapBreak > p->heapBase)
+                            ? (p->heapBreak - p->heapBase) : 0;
+        ++count;
+    }
+
+    return count;
+}
+
 u32 SyscallHandler::sbrk(u32 increment) {
     ProcessManager& pm = ProcessManager::getManager();
     Process* caller = pm.current();
@@ -490,6 +508,9 @@ u32 SyscallHandler::handleSyscall(u32 esp) {
     }
     case SyscallNumber::Sbrk:
         frame->eax = sbrk(frame->ebx);
+        return esp;
+    case SyscallNumber::ProcList:
+        frame->eax = procList((ProcEntry*)frame->ebx, frame->ecx);
         return esp;
     default:
         frame->eax = static_cast<u32>(-1);

--- a/kernel/tests/core/test_proclist.cpp
+++ b/kernel/tests/core/test_proclist.cpp
@@ -1,0 +1,86 @@
+#include <core/syscall.hpp>
+#include <core/process.hpp>
+#include <memory/paging.hpp>
+#include <test.hpp>
+
+using namespace cassio;
+using namespace cassio::kernel;
+using namespace cassio::memory;
+
+TEST(proclist_skips_kernel_task) {
+    SyscallHandler& sh = SyscallHandler::getSyscallHandler();
+
+    ProcEntry buf[16];
+    u32 count = sh.procList(buf, 16);
+
+    // Should not include PID 0 (kernel task).
+    for (u32 i = 0; i < count; ++i) {
+        ASSERT(buf[i].pid != 0);
+    }
+}
+
+TEST(proclist_includes_created_process) {
+    SyscallHandler& sh = SyscallHandler::getSyscallHandler();
+    ProcessManager& pm = ProcessManager::getManager();
+
+    Process* p = pm.create(0x1000, 0x2000, 0x08, 0x10, 0);
+    ASSERT(p != nullptr);
+    p->heapBase = 0x00500000;
+    p->heapBreak = 0x00503000;
+
+    ProcEntry buf[16];
+    u32 count = sh.procList(buf, 16);
+
+    bool found = false;
+    for (u32 i = 0; i < count; ++i) {
+        if (buf[i].pid == p->pid) {
+            found = true;
+            ASSERT_EQ(buf[i].state, static_cast<u32>(ProcessState::Ready));
+            ASSERT_EQ(buf[i].heapSize, 0x3000u);  // 3 pages = 12 KiB.
+            break;
+        }
+    }
+    ASSERT(found);
+
+    pm.destroy(p->pid);
+}
+
+TEST(proclist_zero_heap_size_when_no_heap) {
+    SyscallHandler& sh = SyscallHandler::getSyscallHandler();
+    ProcessManager& pm = ProcessManager::getManager();
+
+    Process* p = pm.create(0x1000, 0x2000, 0x08, 0x10, 0);
+    ASSERT(p != nullptr);
+    // heapBase and heapBreak both 0 (default).
+
+    ProcEntry buf[16];
+    u32 count = sh.procList(buf, 16);
+
+    for (u32 i = 0; i < count; ++i) {
+        if (buf[i].pid == p->pid) {
+            ASSERT_EQ(buf[i].heapSize, 0u);
+            break;
+        }
+    }
+
+    pm.destroy(p->pid);
+}
+
+TEST(proclist_respects_max_entries) {
+    SyscallHandler& sh = SyscallHandler::getSyscallHandler();
+    ProcessManager& pm = ProcessManager::getManager();
+
+    Process* p1 = pm.create(0x1000, 0x2000, 0x08, 0x10, 0);
+    Process* p2 = pm.create(0x1000, 0x2000, 0x08, 0x10, 0);
+    ASSERT(p1 != nullptr);
+    ASSERT(p2 != nullptr);
+
+    ProcEntry buf[1];
+    u32 count = sh.procList(buf, 1);
+
+    // Should return at most 1 entry.
+    ASSERT_EQ(count, 1u);
+
+    pm.destroy(p2->pid);
+    pm.destroy(p1->pid);
+}

--- a/userspace/libs/libcassio/include/ns.hpp
+++ b/userspace/libs/libcassio/include/ns.hpp
@@ -16,6 +16,11 @@
 
 namespace cassio {
 
+struct NsEntry {
+    char name[20];  // MAX_NAME_LEN + 1 + padding for u32 alignment.
+    u32 pid;
+};
+
 class Nameserver {
 public:
     static constexpr u32 PID = 1;
@@ -51,6 +56,13 @@ public:
         msg.type = MessageType::NsLookup;
         packName(name, msg);
         IPC::send(PID, &msg);
+        return msg.arg1;
+    }
+
+    static inline u32 listAll(NsEntry* buf, u32 maxEntries) {
+        Message msg = {};
+        msg.type = MessageType::NsListAll;
+        IPC::send(PID, &msg, buf, maxEntries * sizeof(NsEntry));
         return msg.arg1;
     }
 };

--- a/userspace/libs/libcassio/include/system.hpp
+++ b/userspace/libs/libcassio/include/system.hpp
@@ -87,6 +87,14 @@ public:
                      : "memory");
         return (void*)ret;
     }
+
+    static inline u32 procList(ProcEntry* buf, u32 maxEntries) {
+        u32 ret;
+        asm volatile("int $0x80" : "=a"(ret)
+                     : "a"(SyscallNumber::ProcList), "b"((u32)buf), "c"(maxEntries)
+                     : "memory");
+        return ret;
+    }
 };
 
 } // cassio

--- a/userspace/ns/include/table.hpp
+++ b/userspace/ns/include/table.hpp
@@ -12,6 +12,7 @@
 
 #include <types.hpp>
 #include <list.hpp>
+#include <ns.hpp>
 
 namespace cassio {
 
@@ -29,6 +30,7 @@ public:
 
     u32 registerName(const char* name, u32 pid);
     u32 lookup(const char* name);
+    u32 listAll(NsEntry* buf, u32 maxEntries) const;
     u32 count() const;
 
     NsTable(const NsTable&) = delete;

--- a/userspace/ns/src/main.cpp
+++ b/userspace/ns/src/main.cpp
@@ -29,6 +29,9 @@ static NsTable table;
 extern "C" void _start() {
     UserHeap::init(sbrkGrow, 4096);
 
+    // Self-register (can't use IPC to send to ourselves).
+    table.registerName("ns", Nameserver::PID);
+
     while (true) {
         Message msg;
         i32 sender = IPC::receive(&msg);
@@ -43,13 +46,24 @@ extern "C" void _start() {
         case MessageType::NsRegister:
             Nameserver::unpackName(msg, name);
             reply.arg1 = table.registerName(name, static_cast<u32>(sender));
+            IPC::reply(static_cast<u32>(sender), &reply);
             break;
         case MessageType::NsLookup:
             Nameserver::unpackName(msg, name);
             reply.arg1 = table.lookup(name);
+            IPC::reply(static_cast<u32>(sender), &reply);
+            break;
+        case MessageType::NsListAll: {
+            NsEntry buf[16];
+            u32 count = table.listAll(buf, 16);
+            reply.arg1 = count;
+            IPC::reply(static_cast<u32>(sender), &reply,
+                       buf, count * sizeof(NsEntry));
             break;
         }
-
-        IPC::reply(static_cast<u32>(sender), &reply);
+        default:
+            IPC::reply(static_cast<u32>(sender), &reply);
+            break;
+        }
     }
 }

--- a/userspace/ns/src/table.cpp
+++ b/userspace/ns/src/table.cpp
@@ -41,6 +41,16 @@ u32 NsTable::lookup(const char* name) {
     return 0;
 }
 
+u32 NsTable::listAll(NsEntry* buf, u32 maxEntries) const {
+    u32 count = 0;
+    for (Entry* e = entries.getHead(); e && count < maxEntries; e = e->next) {
+        strcpy(buf[count].name, e->name, 20);
+        buf[count].pid = e->pid;
+        ++count;
+    }
+    return count;
+}
+
 u32 NsTable::count() const {
     return entries.getCount();
 }

--- a/userspace/ns/tests/test_ipc.cpp
+++ b/userspace/ns/tests/test_ipc.cpp
@@ -1,5 +1,6 @@
 #include <test.hpp>
 #include <ns.hpp>
+#include <string.hpp>
 
 using namespace cassio;
 
@@ -34,4 +35,33 @@ TEST(ns_ipc_register_duplicate_fails) {
     Nameserver::registerName("dup_test");
     u32 ok = Nameserver::registerName("dup_test");
     ASSERT_EQ(ok, 0u);
+}
+
+TEST(ns_ipc_list_all_returns_registered_services) {
+    // Services already registered by earlier tests and by the real services
+    // running in the system. Just verify we get a non-zero count and valid data.
+    NsEntry buf[16];
+    u32 count = Nameserver::listAll(buf, 16);
+    ASSERT(count > 0);
+
+    // Every returned entry should have a non-empty name and non-zero PID.
+    for (u32 i = 0; i < count; ++i) {
+        ASSERT(buf[i].name[0] != '\0');
+        ASSERT(buf[i].pid != 0);
+    }
+}
+
+TEST(ns_ipc_list_all_contains_known_service) {
+    // The "kbd" service is always running in the test environment.
+    NsEntry buf[16];
+    u32 count = Nameserver::listAll(buf, 16);
+
+    bool found = false;
+    for (u32 i = 0; i < count; ++i) {
+        if (streq(buf[i].name, "kbd")) {
+            found = true;
+            break;
+        }
+    }
+    ASSERT(found);
 }

--- a/userspace/ns/tests/test_table.cpp
+++ b/userspace/ns/tests/test_table.cpp
@@ -1,5 +1,6 @@
 #include <test.hpp>
 #include <table.hpp>
+#include <string.hpp>
 
 using namespace cassio;
 
@@ -43,4 +44,42 @@ TEST(ns_table_beyond_old_limit) {
         ASSERT_EQ(table.registerName(name, i + 1), 1u);
     }
     ASSERT_EQ(table.count(), 20u);
+}
+
+TEST(ns_table_list_all_returns_entries) {
+    NsTable table;
+    table.registerName("vga", 3);
+    table.registerName("kbd", 2);
+
+    NsEntry buf[8];
+    u32 count = table.listAll(buf, 8);
+    ASSERT_EQ(count, 2u);
+
+    // Verify both entries are present (order may vary).
+    bool foundVga = false;
+    bool foundKbd = false;
+    for (u32 i = 0; i < count; ++i) {
+        if (streq(buf[i].name, "vga") && buf[i].pid == 3) foundVga = true;
+        if (streq(buf[i].name, "kbd") && buf[i].pid == 2) foundKbd = true;
+    }
+    ASSERT(foundVga);
+    ASSERT(foundKbd);
+}
+
+TEST(ns_table_list_all_empty) {
+    NsTable table;
+    NsEntry buf[8];
+    u32 count = table.listAll(buf, 8);
+    ASSERT_EQ(count, 0u);
+}
+
+TEST(ns_table_list_all_respects_max) {
+    NsTable table;
+    table.registerName("a", 1);
+    table.registerName("b", 2);
+    table.registerName("c", 3);
+
+    NsEntry buf[2];
+    u32 count = table.listAll(buf, 2);
+    ASSERT_EQ(count, 2u);
 }

--- a/userspace/shell/include/shell.hpp
+++ b/userspace/shell/include/shell.hpp
@@ -46,6 +46,7 @@ private:
     void cmdClear();
     void cmdEcho(const char** args, u8 argc);
     void cmdMem();
+    void cmdPs();
     void cmdUptime();
     void cmdReboot();
     void cmdShutdown();

--- a/userspace/shell/src/commands/system.cpp
+++ b/userspace/shell/src/commands/system.cpp
@@ -11,6 +11,8 @@
 #include <timer.hpp>
 #include <vga.hpp>
 #include <system.hpp>
+#include <ns.hpp>
+#include <string.hpp>
 
 using namespace cassio;
 
@@ -20,6 +22,7 @@ void Shell::cmdHelp() {
     print("  clear       - Clear the screen\n");
     print("  echo        - Print text\n");
     print("  mem         - Show memory statistics\n");
+    print("  ps          - List running processes\n");
     print("  uptime      - Show time since boot\n");
     print("  reboot      - Reboot the system\n");
     print("  shutdown    - Halt the system\n");
@@ -66,6 +69,64 @@ void Shell::cmdMem() {
     print(" KiB (");
     printDec(free);
     print(" frames)\n");
+}
+
+static const char* stateStr(u32 state) {
+    switch (state) {
+    case 1: return "Ready";
+    case 2: return "Running";
+    case 3: return "SendBlocked";
+    case 4: return "ReceiveBlocked";
+    default: return "Unknown";
+    }
+}
+
+void Shell::cmdPs() {
+    ProcEntry procs[16];
+    u32 procCount = System::procList(procs, 16);
+
+    NsEntry names[16];
+    u32 nameCount = Nameserver::listAll(names, 16);
+
+    print("PID  NAME       STATE           HEAP\n");
+
+    for (u32 i = 0; i < procCount; ++i) {
+        // Find name for this PID.
+        const char* name = "<unknown>";
+        for (u32 j = 0; j < nameCount; ++j) {
+            if (names[j].pid == procs[i].pid) {
+                name = names[j].name;
+                break;
+            }
+        }
+
+        // PID (right-aligned, 3 chars).
+        if (procs[i].pid < 10) print("  ");
+        else if (procs[i].pid < 100) print(" ");
+        printDec(procs[i].pid);
+        print("  ");
+
+        // NAME (left-aligned, 9 chars).
+        print(name);
+        u32 nameLen = strlen(name);
+        for (u32 pad = nameLen; pad < 9; ++pad) {
+            putchar(' ');
+        }
+        print("  ");
+
+        // STATE (left-aligned, 14 chars).
+        const char* state = stateStr(procs[i].state);
+        print(state);
+        u32 stateLen = strlen(state);
+        for (u32 pad = stateLen; pad < 14; ++pad) {
+            putchar(' ');
+        }
+        print("  ");
+
+        // HEAP (in KB).
+        printDec(procs[i].heapSize / 1024);
+        print(" KB\n");
+    }
 }
 
 void Shell::cmdUptime() {

--- a/userspace/shell/src/main.cpp
+++ b/userspace/shell/src/main.cpp
@@ -33,6 +33,8 @@ extern "C" void _start() {
         vfsPid = Nameserver::lookup("vfs");
     }
 
+    Nameserver::registerName("shell");
+
     Shell shell(kbdPid, vgaPid, vfsPid);
     shell.run();
 }

--- a/userspace/shell/src/shell.cpp
+++ b/userspace/shell/src/shell.cpp
@@ -119,6 +119,7 @@ void Shell::execute() {
     else if (streq(args[0], "clear"))    cmdClear();
     else if (streq(args[0], "echo"))     cmdEcho(args, argc);
     else if (streq(args[0], "mem"))      cmdMem();
+    else if (streq(args[0], "ps"))       cmdPs();
     else if (streq(args[0], "uptime"))   cmdUptime();
     else if (streq(args[0], "reboot"))   cmdReboot();
     else if (streq(args[0], "shutdown")) cmdShutdown();


### PR DESCRIPTION
## Summary

- Adds `ps` shell command that displays all userspace processes in a table with PID, NAME, STATE, and HEAP columns
- New `ProcList` syscall (number 14) returns process info from the kernel, skipping PID 0
- New `NsListAll` IPC message type (number 20) for querying all nameserver registrations
- New `heapBase` field in Process struct to compute per-process heap size (`heapBreak - heapBase`)
- Nameserver and shell now self-register so all processes show names in `ps` output

Closes #134

## Test plan

- [x] Kernel tests: 4 new tests for ProcList syscall (131 total, was 127)
- [x] Userspace tests: 5 new tests for NsTable::listAll and NsListAll IPC (94 total, was 89)
- [x] Manual test: `ps` command displays correct table in QEMU

Generated with [Claude Code](https://claude.com/claude-code)